### PR TITLE
Added info-level logging statements to DIprocess.py

### DIFF
--- a/bin/DIprocess.py
+++ b/bin/DIprocess.py
@@ -103,9 +103,11 @@ def main():
          if os.path.isfile(cpfile):
 
              CScmd = 'md5sum ' + cpfile
+             logger.info(cpfile)
              process = subprocess.Popen(CScmd, stdout=subprocess.PIPE, shell=True)
              (stdout, stderr) = process.communicate()
              temp_checksum = stdout.split()[0]
+             logger.info(temp_checksum)
 
              if temp_checksum == Qelement.checksum:
                  Qelement.di_pass = 't'


### PR DESCRIPTION
Added some additional logger.info() statements to DIprocess.py that print which file is being checksummed, and what the checksum actually is. 
This makes the existing DI log more verbose, but will make debugging easier.

A longer-term solution should involve making more effective use of log levels and allowing the verbosity to be passed on the commandline.