### PR TITLE
Initial file_id based database search

### DIFF
--- a/bin/UPC_process.py
+++ b/bin/UPC_process.py
@@ -230,10 +230,6 @@ def main():
                         exband = 'none'
                         for item1 in PDSinfoDICT[getMission(inputfile)]['bandorder']:
                             bandcount = 1
-                            # @TODO causes a type error "int is not iterable."  Need to figure out what this is supposed to do + how to fix it.
-                            print(type(label['IsisCube']['BandBin'][PDSinfoDICT[getMission(inputfile)]['bandbinQuery']]))
-                            print(PDSinfoDICT[getMission(inputfile)]['bandbinQuery'])
-                            print(label['IsisCube']['BandBin'])
                             bands = label['IsisCube']['BandBin'][PDSinfoDICT[getMission(inputfile)]['bandbinQuery']]
                             # Sometime 'bands' is iterable, sometimes it is a single int.  Need to handle both.
                             try:

--- a/bin/UPC_process.py
+++ b/bin/UPC_process.py
@@ -159,7 +159,7 @@ def main():
     err_type_tid = get_tid('errortype', session)
     err_msg_tid = get_tid('errormessage', session)
     err_flag_tid = get_tid('error', session)
-    isis_footprint_id = get_tid('isisfootprint', session)
+    isis_footprint_tid = get_tid('isisfootprint', session)
     isis_centroid_tid = get_tid('isiscentroid', session)
     start_time_tid = get_tid('starttime', session)
     stop_time_tid = get_tid('stoptime', session)
@@ -434,6 +434,7 @@ def main():
                     "%Y-%m-%d %H:%M:%S")
 
                 if '2isis' in processError or processError == 'thmproc':
+                    # @TODO unused variables testspacecraft and testinst
                     testspacecraft = PDSinfoDICT[getMission(
                         inputfile)]['UPCerrorSpacecraft']
                     testinst = PDSinfoDICT[getMission(
@@ -555,7 +556,7 @@ def main():
                     session.merge(DBinput)
 
                     DBinput = MetaTime(upcid=UPCid,
-                                    typeid=star_time_tid,
+                                    typeid=start_time_tid,
                                     value=label['IsisCube']['Instrument']['StartTime'])
                     session.merge(DBinput)
 

--- a/bin/UPCqueueing.py
+++ b/bin/UPCqueueing.py
@@ -65,35 +65,24 @@ def main():
 
     try:
         session, _ = db_connect('pdsdi_dev')
-
         print('Database Connection Success')
     except:
         print('Database Connection Error')
 
     if args.volume:
         volstr = '%' + args.volume + '%'
-
-        Qnum = session.query(Files).filter(Files.archiveid == archiveID,
-                                             Files.filename.like(volstr),
-                                             Files.upc_required == 't').count()
-
-        if Qnum > 0:
-            print("We have files for UPC")
-
-            qOBJ = session.query(Files).filter(Files.archiveid == archiveID,
-                                                 Files.filename.like(volstr),
-                                                 Files.upc_required == 't')
-        else:
-            print("No UPC files found")
-
+        qOBJ = session.query(Files).filter(Files.archiveid == archiveID,
+                                           Files.filename.like(volstr),
+                                           Files.upc_required == 't')
     else:
         qOBJ = session.query(Files).filter(Files.archiveid == archiveID,
                                              Files.upc_required == 't')
     if qOBJ:
         addcount = 0
         for element in qOBJ:
-            Qfile = PDSinfoDICT[args.archive]['path'] + element.filename
-            RQ.QueueAdd(Qfile)
+            fname = PDSinfoDICT[args.archive]['path'] + element.filename
+            fid = element.fileid
+            RQ.QueueAdd((fname, fid))
             addcount = addcount + 1
 
         logger.info('Files Added to UPC Queue: %s', addcount)

--- a/bin/batchUPC.py
+++ b/bin/batchUPC.py
@@ -44,8 +44,9 @@ def main():
 
         # Add each file in the archive to the redis queue.
         for element in result:
-            fName = fpath + element.filename
-            reddis_queue.QueueAdd(fName)
+            fname = fpath + element.filename
+            fid = element.fileid
+            reddis_queue.QueueAdd((fname, fid))
     return 0
 
 


### PR DESCRIPTION
Removes the fuzzy string matching in UPC_process.py.  Instead, the Redis queue now passes a tuple of (filename, fileid) so that no search must take place.  Technically, the tuple is first byte encoded (not sure why), so it is passed as a string of bytes, decoded, and placed into a tuple when it's popped out of the queue.

As expected, this method causes a slight increase in memory usage (the queue now stores more data), but it's only about 10 extra characters per file that's being enqueued.  Only the UPC queue is affected by this update -- the remaining processes did not use fuzzy matching, so passing the fid is not necessary.

On my local machine, UPC processing on themisIR now takes ~3 seconds each, which appears to be a dramatic improvement over the previous implementation.

Closes #60 

This PR also fixes a few typos in variable names in UPC_process