### PR TITLE
Initial softlinking functionality 

### DIFF
--- a/dags/di_process.py
+++ b/dags/di_process.py
@@ -75,6 +75,7 @@ def file_lookup(ds, **kwargs):
     ti = kwargs['ti']
     upstream_tid = kwargs['task'].upstream_task_ids[0]
     in_list = ti.xcom_pull(upstream_tid)
+    if in_list is None : return
     session = kwargs['session']
     out = list()
     for item in in_list:
@@ -88,6 +89,7 @@ def hash_file(ds, **kwargs):
     upstream_tid = kwargs['task'].upstream_task_ids[0]
     archiveID = kwargs['archiveID']
     in_list = ti.xcom_pull(upstream_tid)
+    if in_list is None : return
     out = list()
     for item in in_list:
         cpfile = archiveID[item.archiveid] + item.filename
@@ -106,14 +108,13 @@ def cmp_checksum(ds, **kwargs):
     ti = kwargs['ti']
     upstream_tid = kwargs['task'].upstream_task_ids[0]
     in_list = ti.xcom_pull(upstream_tid)
+    if in_list is None : return
     session = kwargs['session']
     for old, new in in_list:
         if old.checksum == new:
             old.di_pass = True
-            print("PASS")
         else:
             old.di_pass = False
-            print("FAIL")
         old.di_date = datetime.datetime.now(pytz.utc).strftime("%Y-%m-%d %H:%M:%S")
         session.merge(old)
     session.flush()
@@ -161,10 +162,7 @@ def process_subdag(parent_dag_name, child_dag_name, **kwargs):
 def repeat_dag(context, dag_run_obj):
     rq = context['params']['rq']
     if rq.QueueSize() > 0:
-        print('Rerunning dag with {} items left to process'.format(rq.QueueSize()))
         return dag_run_obj
-    else:
-        print('Exiting dag due to empty queue.')
 
 
 

--- a/pds_pipelines/Ingestqueueing.py
+++ b/pds_pipelines/Ingestqueueing.py
@@ -39,12 +39,14 @@ class Args:
         parser.add_argument('--search', '-s', dest="search",
                             help="Enter string to search for")
 
+        parser.add_argument('--link-only', dest='ingest', action='store_false')
+        parser.set_defaults(ingest=True)
         args = parser.parse_args()
 
         self.archive = args.archive
         self.volume = args.volume
         self.search = args.search
-
+        self.ingest = args.ingest
 
 def main():
 
@@ -83,7 +85,8 @@ def main():
                     try:
                         if os.path.basename(fname) == "voldesc.cat":
                             voldescs.append(fname)
-                        RQ_ingest.QueueAdd(fname)
+                        if args.ingest:
+                            RQ_ingest.QueueAdd(fname)
                     except:
                         logger.error('File %s NOT added to Ingest Queue', fname)
                 else:
@@ -92,7 +95,8 @@ def main():
                 try:
                     if os.path.basename(fname) == "voldesc.cat":
                         voldescs.append(fname)
-                    RQ_ingest.QueueAdd(fname)
+                    if args.ingest:
+                        RQ_ingest.QueueAdd(fname)
                 except:
                     logger.error('File %s NOT added to Ingest Queue', fname)
 

--- a/pds_pipelines/LinkArtifacts.py
+++ b/pds_pipelines/LinkArtifacts.py
@@ -1,0 +1,63 @@
+import os
+import pvl
+from xmljson import badgerfish as bf
+from xml.etree.ElementTree import fromstring, ParseError
+from pds_pipelines.config import xml_root
+from pds_pipelines.RedisQueue import RedisQueue
+from ast import literal_eval
+
+def main():
+    RQ = RedisQueue('LinkQueue')
+    while int(RQ.QueueSize()) > 0:
+        # Grab a tuple of values from the redis queue
+        item = literal_eval(RQ.QueueGet().decode('utf-8'))
+        # Split tuple into two values
+        inputfile = item[0]
+        archive = item[1]
+
+        xml_file_path = xml_root + archive + '/config/config.xml'
+        try:
+            xml = parse_xml(xml_file_path)
+        except(ParseError):
+            continue
+        link_src_path = xml['instrument']['path']['file']['$']
+        link_dest_path = xml['instrument']['path']['datalink']['$']
+
+        voldesc = load_pvl(inputfile)
+        dataset_id = format_id(voldesc['VOLUME']['DATA_SET_ID'])
+        volume_id = format_id(voldesc['VOLUME']['VOLUME_ID'])
+
+        src = os.path.join(link_src_path, volume_id)
+        dest = os.path.join(link_dest_path, dataset_id, volume_id)
+        # Split the path into (/tuple/of/, /paths) 
+        link_path = os.path.split(dest)
+        # Create intermediate directories if they don't exist
+        os.makedirs(link_path[0], exist_ok=True)
+        os.symlink(src, dest)
+
+
+def format_id(ds_id):
+    # Remove all quotes, braces, brackets, parentheses, commas, spaces
+    formatted_id = ''.join(c for c in ds_id if c not in '\'\"{}[](), ')
+    formatted_id = formatted_id.replace('/','_')
+    formatted_id = formatted_id.lower()
+    return formatted_id
+
+
+def parse_xml(xml_file_path):
+    with open(xml_file_path) as f:
+        data = f.read()
+        xml = bf.data(fromstring(data))
+    return xml
+
+
+def load_pvl(pvl_file_path):
+    with open(pvl_file_path, 'r') as f:
+        f.readline()
+        data = f.read()
+    voldesc = pvl.loads(data, strict=False)
+    return voldesc
+
+
+if __name__ == '__main__':
+    main()

--- a/pds_pipelines/RedisQueue.py
+++ b/pds_pipelines/RedisQueue.py
@@ -23,7 +23,8 @@ class RedisQueue(object):
         # self.__db=redis.Redis(host=ri['host'], port=ri['port'], db=ri['db'])
         #self.__db=redis.StrictRedis(host=ri['host'], port=ri['port'], db=ri['db'])
         # @TODO change back to non-local queue
-        self.__db = redis.StrictRedis(host='redis')
+        #self.__db = redis.StrictRedis(host='redis')
+        self.__db = redis.StrictRedis(host='localhost')
         self.id_name = '%s:%s' % (namespace, name)
 
     def RemoveAll(self):


### PR DESCRIPTION
LinkArtifacts.py pops a tuple of (filename, archive) off of a redis queue and creates a softlink from the private, in-house data (src) to a public-facing directory (dest).

The script relies on the redis queue "LinkQueue" being externally populated.  The three methods of populating the queue are as follows:
- [x] Manually pushing to queue given a fully qualified path name + archive name
- [x] Running ingestion process with --link-only flag + archive name
- [x] Automated population as part of ingestion process