### PR TITLE
Re-keyed pdsinfo.json and refactored UPC

### DIFF
--- a/pds_pipelines/BatchDI.py
+++ b/pds_pipelines/BatchDI.py
@@ -7,10 +7,11 @@ from pds_pipelines.FindDI_Ready import archive_expired, volume_expired
 from pds_pipelines.RedisQueue import RedisQueue
 from pds_pipelines.db import db_connect
 from pds_pipelines.models.pds_models import Files
+from pds_pipelines.config import pds_info_loc
 
 
 def main():
-    PDS_info = json.load(open('/usgs/cdev/PDS/bin/PDSinfo.json', 'r'))
+    PDS_info = json.load(open(pds_info_loc, 'r'))
     reddis_queue = RedisQueue('DI_ReadyQueue')
 
     try:

--- a/pds_pipelines/DIqueueing.py
+++ b/pds_pipelines/DIqueueing.py
@@ -14,6 +14,7 @@ from pds_pipelines.RedisQueue import *
 from pds_pipelines.HPCjob import *
 from pds_pipelines.db import db_connect
 from pds_pipelines.models.pds_models import Files
+from pds_pipelines.config import pds_info_loc
 
 from sqlalchemy import Date, cast
 
@@ -93,7 +94,7 @@ def main():
 
     RQ = RedisQueue('DI_ReadyQueue')
 
-    PDSinfoDICT = json.load(open('/usgs/cdev/PDS/bin/PDSinfo.json', 'r'))
+    PDSinfoDICT = json.load(open(pds_info_loc, 'r'))
     archiveID = PDSinfoDICT[args.archive]['archiveid']
 
 # ********* Set up logging *************

--- a/pds_pipelines/FindDI_Ready.py
+++ b/pds_pipelines/FindDI_Ready.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.declarative import declarative_base
 
 from pds_pipelines.db import db_connect
 from pds_pipelines.models.pds_models import Files, Archives 
+from pds_pipelines.config import pds_info_loc
 
 import pdb
 
@@ -110,7 +111,7 @@ def main():
     args = Args()
     args.parse_args()
 
-    PDSinfoDICT = json.load(open('/usgs/cdev/PDS/bin/PDSinfo.json', 'r'))
+    PDSinfoDICT = json.load(open(pds_info_loc, 'r'))
     archiveID = PDSinfoDICT[args.archive]['archiveid']
 
     try:

--- a/pds_pipelines/IngestProcess.py
+++ b/pds_pipelines/IngestProcess.py
@@ -7,8 +7,6 @@ import logging
 import json
 
 
-from pds_pipelines.RedisQueue import *
-from pds_pipelines.PDS_DBquery import *
 import hashlib
 import shutil
 
@@ -16,11 +14,14 @@ import sqlalchemy
 from sqlalchemy import *
 from sqlalchemy.orm.util import *
 
+from pds_pipelines.RedisQueue import *
+from pds_pipelines.PDS_DBquery import *
 from pds_pipelines.db import db_connect
+from pds_pipelines.config import pds_info_loc
+from pds_pipelines.models.pds_models import Files, Archives
 
 import pdb
 
-from pds_pipelines.models.pds_models import Files, Archives
 
 
 # @TODO there HAS to be a better way of doing this...
@@ -100,7 +101,7 @@ def main():
     logger.addHandler(logFileHandle)
 
     logger.info("Starting Process")
-    PDSinfoDICT = json.load(open('/usgs/cdev/PDS/bin/PDSinfo.json', 'r'))
+    PDSinfoDICT = json.load(open(pds_info_loc, 'r'))
 
     RQ_main = RedisQueue('Ingest_ReadyQueue')
     RQ_work = RedisQueue('Ingest_WorkQueue')

--- a/pds_pipelines/Ingestqueueing.py
+++ b/pds_pipelines/Ingestqueueing.py
@@ -11,6 +11,7 @@ import argparse
 
 from pds_pipelines.RedisQueue import *
 from pds_pipelines.HPCjob import *
+from pds_pipelines.config import pds_info_loc
 
 import pdb
 
@@ -68,7 +69,7 @@ def main():
     logFileHandle.setFormatter(formatter)
     logger.addHandler(logFileHandle)
 
-    PDSinfoDICT = json.load(open('/usgs/cdev/PDS/bin/PDSinfo.json', 'r'))
+    PDSinfoDICT = json.load(open(pds_info_loc, 'r'))
     archivepath = PDSinfoDICT[args.archive]['path'][:-1]
     if args.volume:
         archivepath = archivepath + '/' + args.volume

--- a/pds_pipelines/PDSinfo.json
+++ b/pds_pipelines/PDSinfo.json
@@ -1,133 +1,88 @@
 {
-    "mroCTX": {
-        "archiveid": "16",
-        "path": "/pds_san/PDS_Archive/Mars_Reconnaissance_Orbiter/CTX/",
-        "mission": "CTX",
-        "UPCrecipe": "/usgs/cdev/PDS/recipe/UPCrecipeCTX.json",
-        "THUMBrecipe": "/usgs/cdev/PDS/recipe/thumbnailrecipeCTX.json",
-        "BROWSErecipe": "/usgs/cdev/PDS/recipe/browserecipeCTX.json",
-        "UPC_XMLpath": "/pds_san/PDS_Derived/UPC/xml/mars_reconnaissance_orbiter/ctx/",
-        "UPC_IMAGEpath": "/pds_san/PDS_Derived/UPC/images/mars_reconnaissance_orbiter/ctx/"
-    },
-    "mroMARCI": {
-        "archiveid": "17",
-        "path": "/pds_san/PDS_Archive/Mars_Reconnaissance_Orbiter/MARCI/",
-        "mission": "MARCI"
-    },
-    "apolloMetric": {
+    "apollo_metric": {
         "archiveid": "97",
         "path": "/pds_san/PDS_Archive/Apollo/Metric_Camera/"
     },
-    "apolloRock": {
+    "apollo_rock": {
         "archiveid": "101",
         "path": "/pds_san/PDS_Archive/Apollo/Rock_Sample_Images/"
     },
-    "lrolrcEDR": {
-        "archiveid": "74",
-        "path": "/pds_san/PDS_Archive/Lunar_Reconnaissance_Orbiter/LROC/EDR/",
-        "UPCrecipe": "/usgs/cdev/PDS/recipe/UPCrecipeLRO_EDR.json",
-        "THUMBrecipe": "/usgs/cdev/PDS/recipe/thumbnailrecipeLRO_EDR.json",
-        "BROWSErecipe": "/usgs/cdev/PDS/recipe/browserecipeLRO_EDR.json"
-    },
-    "lroLAMP": {
-        "archiveid": "84",
-        "path": "/pds_san/PDS_Archive/Lunar_Reconnaissance_Orbiter/LAMP/"
-    },
-    "LCROSS": {
-        "archiveid": "38",
-        "path": "/pds_san/PDS_Archive/LCROSS/"
-    },
-    "cassiniISS": {
+    "cassini_iss": {
         "archiveid": "53",
         "path": "/pds_san/PDS_Archive/Cassini/ISS/"
     },
-    "cassiniRADAR": {
+    "cassini_radar": {
         "archiveid": "51",
         "path": "/pds_san/PDS_Archive/Cassini/RADAR/"
+    },
+    "cassini_vims": {
+        "archiveid": "75",
+        "path": "/pds_san/PDS_Archive/Cassini/VIMS/"
     },
     "chandrayaan_m3": {
         "archiveid": "104",
         "path": "/pds_san/PDS_Archive/Chandrayaan_1/M3/"
     },
-    "cassiniVIMS": {
-        "archiveid": "75",
-        "path": "/pds_san/PDS_Archive/Cassini/VIMS/"
-    },
     "clementine": {
         "archiveid": "50",
         "path": "/pds_san/PDS_Archive/Clementine/"
     },
-    "dawnVesta": {
-        "archiveid": "119",
-        "path": "/pds_san/PDS_Archive/Dawn/Vesta/"
-    },
-    "dawnCeres": {
+    "dawn_ceres": {
         "archiveid": "123",
         "path": "/pds_san/PDS_Archive/Dawn/Ceres/"
     },
-    "galileoNIMS": {
+    "dawn_vesta": {
+        "archiveid": "119",
+        "path": "/pds_san/PDS_Archive/Dawn/Vesta/"
+    },
+    "galileo_nims": {
         "archiveid": "24",
         "path": "/pds_san/PDS_Archive/Galileo/NIMS/"
     },
-    "galileoSSI": {
+    "galileo_ssi_edr": {
         "archiveid": "25",
         "path": "/pds_san/PDS_Archive/Galileo/SSI/"
     },
-    "kaguyaLISM": {
+    "kaguya_lism": {
         "archiveid": "92",
         "path": "/pds_san/PDS_Safed/Data/Kaguya/LISM/"
     },
-    "lunarOrbiter": {
+    "lcross": {
+        "archiveid": "38",
+        "path": "/pds_san/PDS_Archive/LCROSS/"
+    },
+    "lroLAMP": {
+        "archiveid": "84",
+        "path": "/pds_san/PDS_Archive/Lunar_Reconnaissance_Orbiter/LAMP/"
+    },
+    "lro_lroc_edr": {
+        "UPCrecipe": "/usgs/cdev/PDS/recipe/UPCrecipeLRO_EDR.json",
+        "BROWSErecipe": "/usgs/cdev/PDS/recipe/browserecipeLRO_EDR.json",
+        "archiveid": "74",
+        "path": "/pds_san/PDS_Archive/Lunar_Reconnaissance_Orbiter/LROC/EDR/",
+        "THUMBrecipe": "/usgs/cdev/PDS/recipe/thumbnailrecipeLRO_EDR.json"
+    },
+    "lunar_orbiter": {
         "archiveid": "79",
         "path": "/pds_san/PDS_Archive/Lunar_Orbiter/"
-    },
-    "themisIR_EDR": {
-        "archiveid": "116",
-        "path": "/pds_san/PDS_Archive/Mars_Odyssey/THEMIS/USA_NASA_PDS_ODTSDP_100XX/",
-        "bandbinQuery": "FilterNumber",
-        "bandorder": ["9", "8", "7", "6", "5", "4", "3", "2", "1"]
-    },
-    "themisVIS_EDR": {
-        "archiveid": "117",
-        "path": "/pds_san/PDS_Archive/Mars_Odyssey/THEMIS/USA_NASA_PDS_ODTSDP_100XX/"
-    },
-    "themisGEO": {
-        "archiveid": "118",
-        "path": "/pds_san/PDS_Archive/Mars_Odyssey/THEMIS/USA_NASA_PDS_ODTGEO_200XX/"
-    },
-    "mapAplanet": {
-        "archiveid": "41",
-        "path": "/pds_san/PDS_Derived/Map_A_Planet/"
-    },
-    "mroHIRISE_EDR": {
-        "archiveid": "124",
-        "path": "/pds_san/PDS_Archive/Mars_Reconnaissance_Orbiter/HiRISE/"
-    },
-    "mroHIRISE_RDR": {
-        "archiveid": "125",
-        "path": "/pds_san/PDS_Archive/Mars_Reconnaissance_Orbiter/HiRISE/"
-    },
-    "mroHIRISE_EXTRAS": {
-        "archiveid": "126",
-        "path": "/pds_san/PDS_Archive/Mars_Reconnaissance_Orbiter/HiRISE/"
-    },
-    "mroHIRISE": {
-        "archiveid": "71",
-        "path": "/pds_san/PDS_Archive/Mars_Reconnaissance_Orbiter/HiRISE/"
-    },
-    "mariner10": {
-        "archiveid": "46",
-        "path": "/pds_san/PDS_Archive/Mariner_10/"
     },
     "magellan": {
         "archiveid": "27",
         "path": "/pds_san/PDS_Archive/Magellan/"
     },
+    "map_a_planet": {
+        "archiveid": "41",
+        "path": "/pds_san/PDS_Derived/Map_A_Planet/"
+    },
+    "mariner_10": {
+        "archiveid": "46",
+        "path": "/pds_san/PDS_Archive/Mariner_10/"
+    },
     "mars_pathfinder": {
         "archiveid": "18",
         "path": "/pds_san/PDS_Archive/Mars_Pathfinder/"
     },
-    "marsExpress": {
+    "mars_express": {
         "archiveid": "78",
         "path": "/pds_san/PDS_Archive/Mars_Express/"
     },
@@ -135,17 +90,66 @@
         "archiveid": "14",
         "path": "/pds_san/PDS_Archive/MESSENGER/"
     },
-    "MGS_MOC": {
+    "mgs_moc": {
         "archiveid": "44",
         "path": "/pds_san/PDS_Archive/Mars_Global_Surveyor/MOC/"
+    },
+    "mro_ctx": {
+        "UPCrecipe": "/usgs/cdev/PDS/recipe/UPCrecipeCTX.json",
+        "BROWSErecipe": "/usgs/cdev/PDS/recipe/browserecipeCTX.json",
+        "THUMBrecipe": "/usgs/cdev/PDS/recipe/thumbnailrecipeCTX.json",
+        "UPC_IMAGEpath": "/pds_san/PDS_Derived/UPC/images/mars_reconnaissance_orbiter/ctx/",
+        "archiveid": "16",
+        "path": "/pds_san/PDS_Archive/Mars_Reconnaissance_Orbiter/CTX/",
+        "UPC_XMLpath": "/pds_san/PDS_Derived/UPC/xml/mars_reconnaissance_orbiter/ctx/",
+        "mission": "CTX",
+	"bandbinQuery" : "FilterName"
+    },
+    "mro_hirise": {
+        "archiveid": "71",
+        "path": "/pds_san/PDS_Archive/Mars_Reconnaissance_Orbiter/HiRISE/"
+    },
+    "mro_hirise_edr": {
+        "archiveid": "124",
+        "path": "/pds_san/PDS_Archive/Mars_Reconnaissance_Orbiter/HiRISE/"
+    },
+    "mro_hirise_extras": {
+        "archiveid": "126",
+        "path": "/pds_san/PDS_Archive/Mars_Reconnaissance_Orbiter/HiRISE/"
+    },
+    "mro_hirise_rdr": {
+        "archiveid": "125",
+        "path": "/pds_san/PDS_Archive/Mars_Reconnaissance_Orbiter/HiRISE/"
+    },
+    "mro_marci": {
+        "archiveid": "17",
+        "path": "/pds_san/PDS_Archive/Mars_Reconnaissance_Orbiter/MARCI/",
+        "mission": "MARCI"
     },
     "phoenix": {
         "archiveid": "9",
         "path": "/pds_san/PDS_Archive/Phoenix/"
     },
-    "voyager": {
-        "archiveid": "30",
-        "path": "/pds_san/PDS_Archive/Voyager/"
+    "mo_themis_geo": {
+        "archiveid": "118",
+        "path": "/pds_san/PDS_Archive/Mars_Odyssey/THEMIS/USA_NASA_PDS_ODTGEO_200XX/"
+    },
+    "mo_themis_ir_edr": {
+        "bandorder": ["9", "8", "7", "6", "5", "4", "3", "2", "1"],
+        "archiveid": "116",
+	"UPCerrorSpacecraft": "MARS_ODYSSEY",
+        "UPCerrorInstrument": "THEMIS_IR",
+        "path": "/pds_san/PDS_Archive/Mars_Odyssey/THEMIS/USA_NASA_PDS_ODTSDP_100XX/",
+        "bandbinQuery": "FilterNumber"
+    },
+    "mo_themis_vis_edr": {
+	"archiveid" : "117",
+         "path" : "/pds_san/PDS_Archive/Mars_Odyssey/THEMIS/USA_NASA_PDS_ODTSDP_100XX/",
+         "UPCerrorSpacecraft": "MARS_ODYSSEY",
+         "UPCerrorInstrument": "THEMIS_VIS",
+         "bandbinQuery" : "FilterNumber",
+         "bandorder" : ["3", "2", "5", "4", "1"]
+
     },
     "viking_lander": {
         "archiveid": "7",
@@ -154,5 +158,9 @@
     "viking_orbiter": {
         "archiveid": "3",
         "path": "/pds_san/PDS_Archive/Viking_Orbiter/"
+    },
+    "voyager": {
+        "archiveid": "30",
+        "path": "/pds_san/PDS_Archive/Voyager/"
     }
 }

--- a/pds_pipelines/Recipe.py
+++ b/pds_pipelines/Recipe.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 from pds_pipelines.Process import *
 from pds_pipelines.RedisQueue import *
 
-from pds_pipelines.config import recipe_dict
+from pds_pipelines.config import recipe_base
 
 
 class Recipe(Process):
@@ -36,6 +36,7 @@ class Recipe(Process):
         file : str
         """
 
+        # @TODO use 'with' statement for file read
         testjson = json.loads(open(file).read(), object_pairs_hook=OrderedDict)
 
         for IP in testjson[proc]['recipe']:
@@ -68,7 +69,8 @@ class Recipe(Process):
             output
         """
 
-        return recipe_dict[mission]
+        return recipe_base + mission + '.json'
+        #return recipe_dict[mission]
 
 
     def getProcesses(self):

--- a/pds_pipelines/UPC_process.py
+++ b/pds_pipelines/UPC_process.py
@@ -244,8 +244,6 @@ def main():
                                 RQ_thumbnail.QueueAdd(inputfile)
                                 RQ_browse.QueueAdd(inputfile)
                                 label = pvl.load(infile)
-                                print(label)
-                                print(PDSinfoDICT[archive])
                                 infile_bandlist = label['IsisCube']['BandBin'][PDSinfoDICT[archive]['bandbinQuery']]
                                 infile_centerlist = label['IsisCube']['BandBin']['Center']
                             elif item == 'thmproc':

--- a/pds_pipelines/UPC_process.py
+++ b/pds_pipelines/UPC_process.py
@@ -19,29 +19,13 @@ from pds_pipelines.UPCkeywords import *
 from pds_pipelines.db import db_connect
 from pds_pipelines.models import upc_models, pds_models
 from pds_pipelines.models.upc_models import MetaTime, MetaGeometry, MetaString, MetaBoolean
+from pds_pipelines.config import pds_info_loc
 
 from sqlalchemy import *
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.util import *
 
 import pdb
-
-
-def getMission(inputfile):
-    inputfile = str(inputfile)
-    if 'Mars_Reconnaissance_Orbiter/CTX' in inputfile:
-        mission = 'mroCTX'
-    elif 'USA_NASA_PDS_ODTSDP_100XX' in inputfile and 'odtie1' in inputfile:
-        mission = 'themisIR_EDR'
-    elif 'USA_NASA_PDS_ODTSDP_100XX' in inputfile and 'odtve1' in inputfile:
-        mission = 'themisVIS_EDR'
-    elif 'Lunar_Reconnaissance_Orbiter/LROC/EDR/' in inputfile:
-        mission = 'lrolrcEDR'
-    elif 'Cassini/ISS/' in inputfile:
-        mission = 'cassiniISS'
-
-    return mission
-
 
 def getISISid(infile):
     serial_num = getsn(from_=infile)
@@ -135,7 +119,7 @@ def main():
     logFileHandle.setFormatter(formatter)
     logger.addHandler(logFileHandle)
 
-    PDSinfoDICT = json.load(open('/usgs/cdev/PDS/bin/PDSinfo.json', 'r'))
+    PDSinfoDICT = json.load(open(pds_info_loc, 'r'))
 
     # Redis Queue Objects
     RQ_main = RedisQueue('UPC_ReadyQueue')
@@ -157,6 +141,7 @@ def main():
         item = literal_eval(RQ_main.QueueGet().decode("utf-8"))
         inputfile = item[0]
         fid = item[1]
+        archive = item[2]
         #inputfile = (RQ_main.QueueGet()).decode('utf-8')
         if os.path.isfile(inputfile):
             pass
@@ -165,9 +150,12 @@ def main():
         if os.path.isfile(inputfile):
             logger.info('Starting Process: %s', inputfile)
 
+            # @TODO refactor this logic.  We're using an object to find a path, returning it,
+            #  then passing it back to the object so that the object can use it.
             recipeOBJ = Recipe()
-            recip_json = recipeOBJ.getRecipeJSON(getMission(str(inputfile)))
-            recipeOBJ.AddJsonFile(recip_json, 'upc')
+            recipe_json = recipeOBJ.getRecipeJSON(archive)
+            #recipe_json = recipeOBJ.getRecipeJSON(getMission(str(inputfile)))
+            recipeOBJ.AddJsonFile(recipe_json, 'upc')
 
             infile = workarea + os.path.splitext(
                 str(os.path.basename(inputfile)))[0] + '.UPCinput.cub'
@@ -212,7 +200,7 @@ def main():
                         exband = 'none'
                         for item1 in PDSinfoDICT[getMission(inputfile)]['bandorder']:
                             bandcount = 1
-                            bands = label['IsisCube']['BandBin'][PDSinfoDICT[getMission(inputfile)]['bandbinQuery']]
+                            bands = label['IsisCube']['BandBin'][PDSinfoDICT[archive]['bandbinQuery']]
                             # Sometime 'bands' is iterable, sometimes it is a single int.  Need to handle both.
                             try:
                                 for item2 in bands:
@@ -256,16 +244,17 @@ def main():
                                 RQ_thumbnail.QueueAdd(inputfile)
                                 RQ_browse.QueueAdd(inputfile)
                                 label = pvl.load(infile)
-                                infile_bandlist = label['IsisCube']['BandBin'][PDSinfoDICT[getMission(
-                                    inputfile)]['bandbinQuery']]
+                                print(label)
+                                print(PDSinfoDICT[archive])
+                                infile_bandlist = label['IsisCube']['BandBin'][PDSinfoDICT[archive]['bandbinQuery']]
                                 infile_centerlist = label['IsisCube']['BandBin']['Center']
                             elif item == 'thmproc':
                                 RQ_thumbnail.QueueAdd(inputfile)
                                 RQ_browse.QueueAdd(inputfile)
                             elif item == 'handmos':
                                 label = pvl.load(infile)
-                                infile_bandlist = label['IsisCube']['BandBin'][PDSinfoDICT[getMission(
-                                    inputfile)]['bandbinQuery']]
+
+                                infile_bandlist = label['IsisCube']['BandBin'][PDSinfoDICT[archive]['bandbinQuery']]
                                 infile_centerlist = label['IsisCube']['BandBin']['Center']
 
                         except ProcessError as e:
@@ -320,7 +309,7 @@ def main():
 
                 #  Block to add common keywords
                 testjson = json.load(
-                    open('/usgs/cdev/PDS/recipe/Keyword_Definition.json', 'r'))
+                    open('/home/arsanders/PDS-Pipelines/recipe/Keyword_Definition.json', 'r'))
                 for element_1 in testjson['instrument']['COMMON']:
                     keyvalue = ""
                     keytype = testjson['instrument']['COMMON'][element_1]['type']
@@ -366,13 +355,10 @@ def main():
                 session.commit()
 
                 # block to deal with mission keywords
-                for element_2 in testjson['instrument'][getMission(inputfile)]:
-                    M_keytype = testjson['instrument'][getMission(
-                        inputfile)][element_2]['type']
-                    M_keygroup = testjson['instrument'][getMission(
-                        inputfile)][element_2]['group']
-                    M_keyword = testjson['instrument'][getMission(
-                        inputfile)][element_2]['keyword']
+                for element_2 in testjson['instrument'][archive]:
+                    M_keytype = testjson['instrument'][archive][element_2]['type']
+                    M_keygroup = testjson['instrument'][archive][element_2]['group']
+                    M_keyword = testjson['instrument'][archive][element_2]['keyword']
 
                     with session.no_autoflush:
                         M_keyword_Qobj = session.query(upc_models.Keywords).filter(
@@ -431,10 +417,8 @@ def main():
 
                 if '2isis' in processError or processError == 'thmproc':
                     # @TODO unused variables testspacecraft and testinst
-                    testspacecraft = PDSinfoDICT[getMission(
-                        inputfile)]['UPCerrorSpacecraft']
-                    testinst = PDSinfoDICT[getMission(
-                        inputfile)]['UPCerrorInstrument']
+                    testspacecraft = PDSinfoDICT[archive]['UPCerrorSpacecraft']
+                    testinst = PDSinfoDICT[archive]['UPCerrorInstrument']
                     if session.query(upc_models.DataFiles).filter(
                             upc_models.DataFiles.edr_source == EDRsource.decode(
                                 "utf-8")).first() == None:
@@ -572,7 +556,8 @@ def main():
                     session.commit()
 
                 AddProcessDB(pds_session, fid, 'f')
-                os.remove(infile)
+                # @TODO ???
+                #os.remove(infile)
 
 
 if __name__ == "__main__":

--- a/pds_pipelines/UPCqueueing.py
+++ b/pds_pipelines/UPCqueueing.py
@@ -23,13 +23,13 @@ class Args:
 
     def parse_args(self):
 
-        parser = argparse.ArgumentParser(description='PDS DI Data Integrity')
+        parser = argparse.ArgumentParser(description='UPC Queueing')
 
         parser.add_argument('--archive', '-a', dest="archive", required=True,
                             help="Enter archive - archive to ingest")
 
         parser.add_argument('--volume', '-v', dest="volume",
-                            help="Enter voluem to Ingest")
+                            help="Enter volume to Ingest")
 
         parser.add_argument('--search', '-s', dest="search",
                             help="Enter string to search for")
@@ -58,7 +58,7 @@ def main():
 
     logger.info('Starting Process')
 
-    PDSinfoDICT = json.load(open('/usgs/cdev/PDS/bin/PDSinfo.json', 'r'))
+    PDSinfoDICT = json.load(open(pds_info_loc, 'r'))
     archiveID = PDSinfoDICT[args.archive]['archiveid']
 
     RQ = RedisQueue('UPC_ReadyQueue')
@@ -82,7 +82,7 @@ def main():
         for element in qOBJ:
             fname = PDSinfoDICT[args.archive]['path'] + element.filename
             fid = element.fileid
-            RQ.QueueAdd((fname, fid))
+            RQ.QueueAdd((fname, fid, args.archive))
             addcount = addcount + 1
 
         logger.info('Files Added to UPC Queue: %s', addcount)

--- a/pds_pipelines/batchUPC.py
+++ b/pds_pipelines/batchUPC.py
@@ -4,10 +4,11 @@ import json
 from pds_pipelines.RedisQueue import RedisQueue
 from pds_pipelines.db import db_connect
 from pds_pipelines.models.pds_models import Files, Archives
+from pds_pipelines.config import pds_info_loc
 
 
 def main():
-    PDS_info = json.load(open('/usgs/cdev/PDS/bin/PDSinfo.json', 'r'))
+    PDS_info = json.load(open(pds_info_loc, 'r'))
     reddis_queue = RedisQueue('UPC_ReadyQueue')
 
     try:
@@ -46,7 +47,7 @@ def main():
         for element in result:
             fname = fpath + element.filename
             fid = element.fileid
-            reddis_queue.QueueAdd((fname, fid))
+            reddis_queue.QueueAdd((fname, fid, archive_name[0]))
     return 0
 
 

--- a/recipe/Keyword_Definition.json
+++ b/recipe/Keyword_Definition.json
@@ -524,7 +524,7 @@
         "keyword": "GlobalCoverage"
       }
     },
-    "CTX": {
+    "mro_ctx": {
       "statsbandfilter": {
         "type": "string",
         "displayname": "Band Filter Used For Statistics",
@@ -586,7 +586,7 @@
         "keyword": "DATA_SET_ID"  
       }
     },
-    "themisIR_EDR": {
+    "themis_ir_edr": {
       "gainnumber": {
         "type": "integer",
         "displayname": "Gain Number",

--- a/recipe/new/clementine.json
+++ b/recipe/new/clementine.json
@@ -1,8 +1,8 @@
 {
-    "inst": "voyager_jupiter",
+    "inst": "clementine_edr",
     "upc": {
         "recipe": {
-            "voy2isis": {
+            "clem2isis": {
                 "from_": "value",
                 "to": "value"
             },
@@ -40,7 +40,7 @@
     },
     "pow": {
         "recipe": {
-            "voy2isis": {
+            "clem2isis": {
                 "from_": "value",
                 "to": "value"
             },
@@ -53,7 +53,7 @@
     },
     "reduced": {
         "recipe": {
-            "voy2isis": {
+            "clem2isis": {
                 "from_": "value",
                 "to": "value"
             },
@@ -83,7 +83,7 @@
     },
     "projected": {
         "recipe": {
-            "voy2isis": {
+            "clem2isis": {
                 "from_": "value",
                 "to": "value"
             },

--- a/recipe/new/kaguya_lism.json
+++ b/recipe/new/kaguya_lism.json
@@ -1,0 +1,15 @@
+{
+    "inst": "kaguya_lism_tc_evening",
+    "upc": {
+        "recipe": {}
+    },
+    "pow": {
+        "recipe": {}
+    },
+    "reduced": {
+        "recipe": {}
+    },
+    "projected": {
+        "recipe": {}
+    }
+}

--- a/recipe/new/magellan.json
+++ b/recipe/new/magellan.json
@@ -1,0 +1,15 @@
+{
+    "inst": "magellan_alt",
+    "upc": {
+        "recipe": {}
+    },
+    "pow": {
+        "recipe": {}
+    },
+    "reduced": {
+        "recipe": {}
+    },
+    "projected": {
+        "recipe": {}
+    }
+}

--- a/recipe/new/mars_express.json
+++ b/recipe/new/mars_express.json
@@ -1,21 +1,23 @@
 {
-    "inst": "voyager_jupiter",
+    "inst": "mars_express_rdr",
     "upc": {
         "recipe": {
-            "voy2isis": {
+            "hrsc2isis": {
                 "from_": "value",
                 "to": "value"
             },
             "spiceinit": {
                 "from_": "value",
-                "cknadir": "yes",
-                "cksmithed": "yes"
+                "cksmithed": "yes",
+                "ckrecon": "yes",
+                "ckpredicted": "yes",
+                "cknadir": "no"
             },
             "footprintinit": {
                 "from_": "value",
                 "increaseprecision": "yes",
                 "inctype": "vertices",
-                "numvertices": "20",
+                "numvertices": "40",
                 "maxemission": "89.5",
                 "maxincidence": "120.0"
             },
@@ -24,14 +26,14 @@
                 "to": "value",
                 "geometry": "yes",
                 "isislabel": "yes",
-                "originallabel": "yes",
+                "originallabel": "no",
                 "statistics": "yes",
                 "camstats": "yes",
-                "linc": "10",
-                "sinc": "10",
+                "linc": "100",
+                "sinc": "100",
                 "polygon": "yes",
                 "inctype": "vertices",
-                "numvertices": "20",
+                "numvertices": "40",
                 "maxemission": "89.5",
                 "maxincidence": "120.0",
                 "spice": "no"
@@ -40,27 +42,39 @@
     },
     "pow": {
         "recipe": {
-            "voy2isis": {
+            "hrsc2isis": {
                 "from_": "value",
                 "to": "value"
             },
             "spiceinit": {
                 "from_": "value",
-                "cknadir": "yes",
-                "cksmithed": "yes"
+                "cksmithed": "yes",
+                "ckrecon": "yes",
+                "ckpredicted": "yes",
+                "cknadir": "no"
+            },
+            "cam2map": {
+                "from": "value",
+                "to": "value",
+                "map": "value",
+                "matchmap": "no",
+                "pixres": "value",
+                "defaultrange": "value"
             }
         }
     },
     "reduced": {
         "recipe": {
-            "voy2isis": {
+            "hrsc2isis": {
                 "from_": "value",
                 "to": "value"
             },
             "spiceinit": {
                 "from_": "value",
-                "cknadir": "yes",
-                "cksmithed": "yes"
+                "cksmithed": "yes",
+                "ckrecon": "yes",
+                "ckpredicted": "yes",
+                "cknadir": "no"
             },
             "reduce": {
                 "from_": "value",
@@ -83,14 +97,16 @@
     },
     "projected": {
         "recipe": {
-            "voy2isis": {
+            "hrsc2isis": {
                 "from_": "value",
                 "to": "value"
             },
             "spiceinit": {
                 "from_": "value",
-                "cknadir": "yes",
-                "cksmithed": "yes"
+                "cksmithed": "yes",
+                "ckrecon": "yes",
+                "ckpredicted": "yes",
+                "cknadir": "no"
             },
             "isis2std": {
                 "from_": "value",

--- a/recipe/new/mars_pathfinder.json
+++ b/recipe/new/mars_pathfinder.json
@@ -1,0 +1,15 @@
+{
+    "inst": "mars_pathfinder_edr",
+    "upc": {
+        "recipe": {}
+    },
+    "pow": {
+        "recipe": {}
+    },
+    "reduced": {
+        "recipe": {}
+    },
+    "projected": {
+        "recipe": {}
+    }
+}

--- a/recipe/new/messenger.json
+++ b/recipe/new/messenger.json
@@ -1,8 +1,8 @@
 {
-    "inst": "voyager_jupiter",
+    "inst": "messenger_edr",
     "upc": {
         "recipe": {
-            "voy2isis": {
+            "mdis2isis": {
                 "from_": "value",
                 "to": "value"
             },
@@ -15,7 +15,7 @@
                 "from_": "value",
                 "increaseprecision": "yes",
                 "inctype": "vertices",
-                "numvertices": "20",
+                "numvertices": "40",
                 "maxemission": "89.5",
                 "maxincidence": "120.0"
             },
@@ -31,7 +31,7 @@
                 "sinc": "10",
                 "polygon": "yes",
                 "inctype": "vertices",
-                "numvertices": "20",
+                "numvertices": "40",
                 "maxemission": "89.5",
                 "maxincidence": "120.0",
                 "spice": "no"
@@ -40,7 +40,7 @@
     },
     "pow": {
         "recipe": {
-            "voy2isis": {
+            "mdis2isis": {
                 "from_": "value",
                 "to": "value"
             },
@@ -48,12 +48,24 @@
                 "from_": "value",
                 "cknadir": "yes",
                 "cksmithed": "yes"
+            },
+            "mdiscal": {
+                "from_": "value",
+                "to": "value"
+            },
+            "cam2map": {
+                "from": "value",
+                "to": "value",
+                "map": "value",
+                "matchmap": "no",
+                "pixres": "value",
+                "defaultrange": "value"
             }
         }
     },
     "reduced": {
         "recipe": {
-            "voy2isis": {
+            "mdis2isis": {
                 "from_": "value",
                 "to": "value"
             },
@@ -61,6 +73,10 @@
                 "from_": "value",
                 "cknadir": "yes",
                 "cksmithed": "yes"
+            },
+            "mdiscal": {
+                "from_": "value",
+                "to": "value"
             },
             "reduce": {
                 "from_": "value",
@@ -83,7 +99,7 @@
     },
     "projected": {
         "recipe": {
-            "voy2isis": {
+            "mdis2isis": {
                 "from_": "value",
                 "to": "value"
             },
@@ -91,6 +107,10 @@
                 "from_": "value",
                 "cknadir": "yes",
                 "cksmithed": "yes"
+            },
+            "mdiscal": {
+                "from_": "value",
+                "to": "value"
             },
             "isis2std": {
                 "from_": "value",

--- a/recipe/new/messenger_mission.json
+++ b/recipe/new/messenger_mission.json
@@ -54,8 +54,8 @@
                 "spkpredicted": "yes"
             },
 	    "mdiscal": {
-            "from_": "value",
-            "to": "value"
+            	"from_": "value",
+           	 "to": "value"
             },
             "cam2map": {
 		    "from_": "value",

--- a/recipe/new/mgs_moc.json
+++ b/recipe/new/mgs_moc.json
@@ -1,0 +1,50 @@
+{
+    "inst": "mgs_moc_na",
+    "upc": {
+        "recipe": {}
+    },
+    "pow": {
+        "recipe": {
+            "moc2isis": {
+                "from_": "value",
+                "to": "value"
+            },
+            "moccal": {
+                "from_": "value",
+                "to": "value"
+            },
+            "mocnoise50": {
+                "from_": "value",
+                "to": "value"
+            },
+            "mocevenodd": {
+                "from_": "value",
+                "to": "value"
+            },
+            "cam2map": {
+                "from": "value",
+                "to": "value",
+                "map": "value",
+                "matchmap": "no",
+                "pixres": "value",
+                "defaultrange": "value"
+            }
+        }
+    },
+    "reduced": {
+        "recipe": {
+            "moccal": {
+                "from_": "value",
+                "to": "value"
+            }
+        }
+    },
+    "projected": {
+        "recipe": {
+            "moccal": {
+                "from_": "value",
+                "to": "value"
+            }
+        }
+    }
+}

--- a/recipe/new/mro_hirise.json
+++ b/recipe/new/mro_hirise.json
@@ -1,15 +1,104 @@
 {
     "inst": "mro_hirise",
     "upc": {
-        "recipe": {}
+        "recipe": {
+            "hi2isis": {
+                "from_": "value",
+                "to": "value"
+            },
+            "spiceinit": {
+                "from_": "value",
+                "cknadir": "yes",
+                "cksmithed": "yes"
+            },
+            "footprintinit": {
+                "from_": "value",
+                "increaseprecision": "yes",
+                "inctype": "vertices",
+                "numvertices": "40",
+                "maxemission": "89.5",
+                "maxincidence": "120.0"
+            },
+            "caminfo": {
+                "from_": "value",
+                "to": "value",
+                "geometry": "yes",
+                "isislabel": "yes",
+                "originallabel": "yes",
+                "statistics": "yes",
+                "camstats": "yes",
+                "linc": "100",
+                "sinc": "100",
+                "polygon": "yes",
+                "inctype": "vertices",
+                "numvertices": "40",
+                "maxemission": "89.5",
+                "maxincidence": "120.0",
+                "spice": "no"
+            }
+        }
     },
     "pow": {
-        "recipe": {}
+        "recipe": {
+            "hi2isis": {
+                "from_": "value",
+                "to": "value"
+            },
+            "spiceinit": {
+                "from_": "value",
+                "cknadir": "yes",
+                "cksmithed": "yes"
+            }
+        }
     },
     "reduced": {
-        "recipe": {}
+        "recipe": {
+            "hi2isis": {
+                "from_": "value",
+                "to": "value"
+            },
+            "spiceinit": {
+                "from_": "value",
+                "cknadir": "yes",
+                "cksmithed": "yes"
+            },
+            "reduce": {
+                "from_": "value",
+                "to": "value",
+                "algorithm": "average",
+                "mode": "scale",
+                "sscale": "value",
+                "lscale": "value",
+                "validper": "1",
+                "vper_replace": "nearest"
+            },
+            "isis2std": {
+                "from_": "value",
+                "to": "value",
+                "format": "jpeg",
+                "quality": "60",
+                "stretch": "linear"
+            }
+        }
     },
     "projected": {
-        "recipe": {}
+        "recipe": {
+            "hi2isis": {
+                "from_": "value",
+                "to": "value"
+            },
+            "spiceinit": {
+                "from_": "value",
+                "cknadir": "yes",
+                "cksmithed": "yes"
+            },
+            "isis2std": {
+                "from_": "value",
+                "to": "value",
+                "format": "jpeg",
+                "quality": "60",
+                "stretch": "linear"
+            }
+        }
     }
 }

--- a/recipe/new/mro_hirise_edr.json
+++ b/recipe/new/mro_hirise_edr.json
@@ -1,8 +1,8 @@
 {
-    "inst": "voyager_jupiter",
+    "inst": "mro_hirise_edr_psp",
     "upc": {
         "recipe": {
-            "voy2isis": {
+            "hi2isis": {
                 "from_": "value",
                 "to": "value"
             },
@@ -15,7 +15,7 @@
                 "from_": "value",
                 "increaseprecision": "yes",
                 "inctype": "vertices",
-                "numvertices": "20",
+                "numvertices": "40",
                 "maxemission": "89.5",
                 "maxincidence": "120.0"
             },
@@ -27,11 +27,11 @@
                 "originallabel": "yes",
                 "statistics": "yes",
                 "camstats": "yes",
-                "linc": "10",
-                "sinc": "10",
+                "linc": "100",
+                "sinc": "100",
                 "polygon": "yes",
                 "inctype": "vertices",
-                "numvertices": "20",
+                "numvertices": "40",
                 "maxemission": "89.5",
                 "maxincidence": "120.0",
                 "spice": "no"
@@ -40,7 +40,7 @@
     },
     "pow": {
         "recipe": {
-            "voy2isis": {
+            "hi2isis": {
                 "from_": "value",
                 "to": "value"
             },
@@ -53,7 +53,7 @@
     },
     "reduced": {
         "recipe": {
-            "voy2isis": {
+            "hi2isis": {
                 "from_": "value",
                 "to": "value"
             },
@@ -83,7 +83,7 @@
     },
     "projected": {
         "recipe": {
-            "voy2isis": {
+            "hi2isis": {
                 "from_": "value",
                 "to": "value"
             },

--- a/recipe/new/mro_hirise_extras.json
+++ b/recipe/new/mro_hirise_extras.json
@@ -1,0 +1,15 @@
+{
+    "inst": "mro_hirise_extras_ana_esp",
+    "upc": {
+        "recipe": {}
+    },
+    "pow": {
+        "recipe": {}
+    },
+    "reduced": {
+        "recipe": {}
+    },
+    "projected": {
+        "recipe": {}
+    }
+}

--- a/recipe/new/mro_hirise_rdr.json
+++ b/recipe/new/mro_hirise_rdr.json
@@ -1,0 +1,59 @@
+{
+    "inst": "mro_hirise_rdr_esp",
+    "upc": {
+        "recipe": {
+            "pds2isis": {
+                "from_": "value",
+                "to": "value"
+            }
+        }
+    },
+    "pow": {
+        "recipe": {
+            "pds2isis": {
+                "from_": "value",
+                "to": "value"
+            }
+        }
+    },
+    "reduced": {
+        "recipe": {
+            "pds2isis": {
+                "from_": "value",
+                "to": "value"
+            },
+            "reduce": {
+                "from_": "value",
+                "to": "value",
+                "algorithm": "average",
+                "mode": "scale",
+                "sscale": "value",
+                "lscale": "value",
+                "validper": "1",
+                "vper_replace": "nearest"
+            },
+            "isis2std": {
+                "from_": "value",
+                "to": "value",
+                "format": "jpeg",
+                "quality": "60",
+                "stretch": "linear"
+            }
+        }
+    },
+    "projected": {
+        "recipe": {
+            "pds2isis": {
+                "from_": "value",
+                "to": "value"
+            },
+            "isis2std": {
+                "from_": "value",
+                "to": "value",
+                "format": "jpeg",
+                "quality": "60",
+                "stretch": "linear"
+            }
+        }
+    }
+}

--- a/recipe/new/phoenix.json
+++ b/recipe/new/phoenix.json
@@ -1,0 +1,15 @@
+{
+    "inst": "phoenix_mosaics_rdr",
+    "upc": {
+        "recipe": {}
+    },
+    "pow": {
+        "recipe": {}
+    },
+    "reduced": {
+        "recipe": {}
+    },
+    "projected": {
+        "recipe": {}
+    }
+}

--- a/recipe/new/viking_lander.json
+++ b/recipe/new/viking_lander.json
@@ -1,0 +1,15 @@
+{
+    "inst": "viking_lander_edr",
+    "upc": {
+        "recipe": {}
+    },
+    "pow": {
+        "recipe": {}
+    },
+    "reduced": {
+        "recipe": {}
+    },
+    "projected": {
+        "recipe": {}
+    }
+}


### PR DESCRIPTION
Added additional recipes for UPC / POW processing.

Re-keyed pdsinfo.json to follow naming convention of UPC / POW config files, which allowed for a refactor of upc processing.  This refactor allows us to simply access a config file based on archive name instead of creating / maintaining mappings between input files -> archive names -> config file names.  It is important to note that it is now critical to ensure that config file names directly match the name of the archive that they describe.

Moved definition of pds_info.json file path to a config file so that there is now a single definition that can be changed if we want to use a different .json file.