### PR TITLE
Added more helpful error resolution information when user specified archive is not found

### DIFF
--- a/pds_pipelines/DIqueueing.py
+++ b/pds_pipelines/DIqueueing.py
@@ -87,7 +87,7 @@ class Args:
 def main():
 
 
-    pdb.set_trace()
+    #pdb.set_trace()
 
     args = Args()
     args.parse_args()
@@ -95,7 +95,14 @@ def main():
     RQ = RedisQueue('DI_ReadyQueue')
 
     PDSinfoDICT = json.load(open(pds_info_loc, 'r'))
-    archiveID = PDSinfoDICT[args.archive]['archiveid']
+    try:
+        archiveID = PDSinfoDICT[args.archive]['archiveid']
+    except KeyError:
+        print("\nArchive '{}' not found in {}\n".format(args.archive, pds_info_loc))
+        print("The following archives are available:")
+        for k in PDSinfoDICT.keys():
+            print("\t{}".format(k))
+        exit()
 
 # ********* Set up logging *************
     logger = logging.getLogger('DI_Queueing.' + args.archive)

--- a/pds_pipelines/FindDI_Ready.py
+++ b/pds_pipelines/FindDI_Ready.py
@@ -112,7 +112,14 @@ def main():
     args.parse_args()
 
     PDSinfoDICT = json.load(open(pds_info_loc, 'r'))
-    archiveID = PDSinfoDICT[args.archive]['archiveid']
+    try:
+        archiveID = PDSinfoDICT[args.archive]['archiveid']
+    except KeyError:
+        print("\nArchive '{}' not found in {}\n".format(args.archive, pds_info_loc))
+        print("The following archives are available:")
+        for k in PDSinfoDICT.keys():
+            print("\t{}".format(k))
+        exit()
 
     try:
         # Throws away 'engine' information

--- a/pds_pipelines/Ingestqueueing.py
+++ b/pds_pipelines/Ingestqueueing.py
@@ -70,7 +70,15 @@ def main():
     logger.addHandler(logFileHandle)
 
     PDSinfoDICT = json.load(open(pds_info_loc, 'r'))
-    archivepath = PDSinfoDICT[args.archive]['path'][:-1]
+    try:
+        archivepath = PDSinfoDICT[args.archive]['path'][:-1]
+    except KeyError:
+        print("\nArchive '{}' not found in {}\n".format(args.archive, pds_info_loc))
+        print("The following archives are available:")
+        for k in PDSinfoDICT.keys():
+            print("\t{}".format(k))
+        exit()
+
     if args.volume:
         archivepath = archivepath + '/' + args.volume
 

--- a/pds_pipelines/PDSinfo.json
+++ b/pds_pipelines/PDSinfo.json
@@ -95,13 +95,8 @@
         "path": "/pds_san/PDS_Archive/Mars_Global_Surveyor/MOC/"
     },
     "mro_ctx": {
-        "UPCrecipe": "/usgs/cdev/PDS/recipe/UPCrecipeCTX.json",
-        "BROWSErecipe": "/usgs/cdev/PDS/recipe/browserecipeCTX.json",
-        "THUMBrecipe": "/usgs/cdev/PDS/recipe/thumbnailrecipeCTX.json",
-        "UPC_IMAGEpath": "/pds_san/PDS_Derived/UPC/images/mars_reconnaissance_orbiter/ctx/",
         "archiveid": "16",
         "path": "/pds_san/PDS_Archive/Mars_Reconnaissance_Orbiter/CTX/",
-        "UPC_XMLpath": "/pds_san/PDS_Derived/UPC/xml/mars_reconnaissance_orbiter/ctx/",
         "mission": "CTX",
 	"bandbinQuery" : "FilterName"
     },

--- a/pds_pipelines/UPC_process.py
+++ b/pds_pipelines/UPC_process.py
@@ -198,7 +198,7 @@ def main():
                         processOBJ.updateParameter('from_', infile)
                     elif item == 'cubeatt':
                         exband = 'none'
-                        for item1 in PDSinfoDICT[getMission(inputfile)]['bandorder']:
+                        for item1 in PDSinfoDICT[archive]['bandorder']:
                             bandcount = 1
                             bands = label['IsisCube']['BandBin'][PDSinfoDICT[archive]['bandbinQuery']]
                             # Sometime 'bands' is iterable, sometimes it is a single int.  Need to handle both.

--- a/pds_pipelines/UPC_process.py
+++ b/pds_pipelines/UPC_process.py
@@ -197,6 +197,9 @@ def main():
                     elif item == 'spiceinit':
                         processOBJ.updateParameter('from_', infile)
                     elif item == 'cubeatt':
+                        """
+                        # @TODO revisit this block to make sure that it can be deleted without
+                        #  affecting integrity of downstream products.
                         exband = 'none'
                         for item1 in PDSinfoDICT[archive]['bandorder']:
                             bandcount = 1
@@ -215,6 +218,8 @@ def main():
                                     exband = 1
                                     break
                         band_infile = infile + '+' + str(exband)
+                        """
+                        band_infile = infile + '+' + str(1)
                         processOBJ.updateParameter('from_', band_infile)
                         processOBJ.updateParameter('to', outfile)
                     elif item == 'footprintinit':
@@ -554,8 +559,7 @@ def main():
                     session.commit()
 
                 AddProcessDB(pds_session, fid, 'f')
-                # @TODO ???
-                #os.remove(infile)
+                os.remove(infile)
 
 
 if __name__ == "__main__":

--- a/pds_pipelines/UPCqueueing.py
+++ b/pds_pipelines/UPCqueueing.py
@@ -59,7 +59,14 @@ def main():
     logger.info('Starting Process')
 
     PDSinfoDICT = json.load(open(pds_info_loc, 'r'))
-    archiveID = PDSinfoDICT[args.archive]['archiveid']
+    try:
+        archiveID = PDSinfoDICT[args.archive]['archiveid']
+    except KeyError:
+        print("\nArchive '{}' not found in {}\n".format(args.archive, pds_info_loc))
+        print("The following archives are available:")
+        for k in PDSinfoDICT.keys():
+            print("\t{}".format(k))
+        exit()
 
     RQ = RedisQueue('UPC_ReadyQueue')
 

--- a/pds_pipelines/browse_process.py
+++ b/pds_pipelines/browse_process.py
@@ -2,37 +2,43 @@
 import os
 import sys
 import pvl
+import json
+import datetime
+import pytz
 import logging
-import shutil
+
+from ast import literal_eval
+
 from pysis import isis
 from pysis.exceptions import ProcessError
+from pysis.isis import getsn
 
 from pds_pipelines.RedisQueue import *
 from pds_pipelines.Recipe import *
+from pds_pipelines.db import db_connect
+from pds_pipelines.models.upc_models import MetaString, DataFiles
+from pds_pipelines.models.pds_models import ProcessRuns, Files
+from pds_pipelines.config import pds_log_loc, pds_info_loc
 
 import pdb
 
+def getISISid(infile):
+    serial_num = getsn(from_=infile)
+    if isinstance(serial_num, bytes):
+        serial_num = serial_num.decode()
+    newisisSerial = serial_num.replace('\n', '')
+    return newisisSerial
 
-def scaleFactor(line, sample):
-    """
-    Calculates and returns a ratio
+def scaleFactor(line, sample, jsonfile):
 
-    Parameters
-    ----------
-    line:int
-    sample:int
+#    pdb.set_trace()
 
-    Returns
-    -------
-    int
-        scalefactor: ratio of 'line' to maxLine or minLine and 
-        'sample' to maxSample or minSample
-    """
+    infoDICT = json.load(open(jsonfile, 'r'))   
 
-    maxLine = 900
-    maxSample = 900
-    minLine = 300
-    minSample = 300
+    maxLine = int(infoDICT['reduced']['browse']['maxlines'])
+    maxSample = int(infoDICT['reduced']['browse']['maxsamples'])
+    minLine = int(infoDICT['reduced']['browse']['minlines'])
+    minSample = int(infoDICT['reduced']['browse']['minsamples'])
 
     if sample < line:
         scalefactor = line/maxLine
@@ -44,96 +50,137 @@ def scaleFactor(line, sample):
     else:
         scalefactor = sample/maxSample
         testline = int(line/scalefactor)
-
+         
         if testline < minLine:
             scalefactor = line/minLine
 
+    if scalefactor < 1:
+        scalefactor = 1
     return scalefactor
 
 
 def makedir(inputfile):
-    """
-    Replaces '/pds_san/pds_archive/' in the directory component of 'inputfile'
-    with '/pds_san/PDS_Derived/UPC/images/'
-
-    Parameters
-    ----------
-    inputfile
-
-    Returns
-    -------
-    str
-        finalpath
-    """
+#    pdb.set_trace()
 
     temppath = os.path.dirname(inputfile).lower()
-    finalpath = temppath.replace(
-        '/pds_san/pds_archive/', '/pds_san/PDS_Derived/UPC/images/')
+    finalpath = temppath.replace('/pds_san/pds_archive/', '/pds_san/PDS_Derived/UPC/images/')
 
     if not os.path.exists(finalpath):
         try:
-            os.makedirs(finalpath, 0755)
+            os.makedirs(finalpath, exist_ok=True)
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
 
     return finalpath
 
+def DB_addURL(session, isisSerial, inputfile):
+
+    # pdb.set_trace()
+    newisisSerial = isisSerial.split(':')[0]
+    likestr = '%' + newisisSerial + '%'
+    Qobj = session.query(datafiles).filter(datafiles.isisid.like(likestr)).first()
+
+    if str(Qobj.isisid) == str(isisSerial):
+
+        outputfile = inputfile.replace('/pds_san/PDS_Derived/UPC/images/', '$browse_server/')
+
+        DBinput = meta_string(upcid=Qobj.upcid,
+                            typeid='348',
+                            value=outputfile)
+
+        try:
+            session.add(DBinput)
+            session.commit()
+            return 'SUCCESS'
+        except:
+            return 'ERROR'
+
+
+def AddProcessDB(session, fid, outvalue):
+    # pdb.set_trace()
+    date = datetime.datetime.now(pytz.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+    processDB = pds_models.ProcessRuns(fileid=fid,
+                             process_date=date,
+                             process_typeid='5',
+                             process_out=outvalue)
+
+    try:
+        session.merge(processDB)
+        session.commit()
+        return 'SUCCESS'
+    except:
+        return 'ERROR'
+
 
 def main():
 
-    #    pdb.set_trace()
+#    pdb.set_trace()
 
-    workarea = '/scratch/pds_services/workarea/'
+    # @TODO move to config file
+    workarea = '/home/arsanders/PDS-Pipelines/products/'
+    # workarea = '/scratch/pds_services/workarea/'
 
-# ***************** Set up logging *****************
+##***************** Set up logging *****************
     logger = logging.getLogger('Browse_Process')
     logger.setLevel(logging.INFO)
-    logFileHandle = logging.FileHandler('/usgs/cdev/PDS/logs/Process.log')
-    formatter = logging.Formatter(
-        '%(asctime)s - %(name)s - %(levelname)s, %(message)s')
+    logFileHandle = logging.FileHandler(pds_log_loc + 'Process.log')
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s, %(message)s')
     logFileHandle.setFormatter(formatter)
-    logger.addHandler(logFileHandle)
+    logger.addHandler(logFileHandle)    
 
     RQ_main = RedisQueue('Browse_ReadyQueue')
 
-    while int(RQ_main.QueueSize()) > 0:
+    PDSinfoDICT = json.load(open(pds_info_loc, 'r'))
 
-        inputfile = RQ_main.QueueGet()
+    pds_session = db_connect('pdsdi_dev')
+    upc_session = db_connect('upcdev')
+
+    while int(RQ_main.QueueSize()) > 0:
+        item = literal_eval(RQ_main.QueueGet().decode("utf-8"))
+        inputfile = item[0]
+        fid = item[1]
+        archive = item[2]
         if os.path.isfile(inputfile):
             logger.info('Starting Process: %s', inputfile)
-
-            if 'Mars_Reconnaissance_Orbiter/CTX/' in inputfile:
-                mission = 'CTX'
-
-# ********** Derived DIR path Stuff **********************
             finalpath = makedir(inputfile)
 
             recipeOBJ = Recipe()
-            recip_json = recipeOBJ.getRecipeJSON(mission)
+            recip_json = recipeOBJ.getRecipeJSON(archive)
             recipeOBJ.AddJsonFile(recip_json, 'reduced')
-
-            infile = workarea + \
-                os.path.splitext(os.path.basename(inputfile))[
-                    0] + '.Binput.cub'
-            outfile = workarea + \
-                os.path.splitext(os.path.basename(inputfile))[
-                    0] + '.Boutput.cub'
-
+            infile = workarea + os.path.splitext(os.path.basename(inputfile))[0] + '.Binput.cub'
+            outfile = workarea + os.path.splitext(os.path.basename(inputfile))[0] + '.Boutput.cub'
             status = 'success'
             for item in recipeOBJ.getProcesses():
                 if status == 'error':
                     break
                 elif status == 'success':
                     processOBJ = Process()
-                    processR = processOBJ.ProcessFromRecipe(
-                        item, recipeOBJ.getRecipe())
+                    processR = processOBJ.ProcessFromRecipe(item, recipeOBJ.getRecipe())
 
                     if '2isis' in item:
                         processOBJ.updateParameter('from_', inputfile)
                         processOBJ.updateParameter('to', outfile)
                     elif item == 'spiceinit':
                         processOBJ.updateParameter('from_', infile)
+                    elif item == 'cubeatt':
+                        label = pvl.load(infile)
+                        bands = PDSinfoDICT[archive]['bandorder']
+                        query_bands = label['IsisCube']['BandBin'][PDSinfoDICT[archive]['bandbinQuery']]
+                        # Create a set from the list / single value
+                        try:
+                            query_band_set = set(query_bands)
+                        except:
+                            query_band_set = set([query_bands])
+                        
+                        # Iterate through 'bands' and grab the first value that is present in the
+                        #  set defined by 'bandbinquery' -- if not present, default to 1
+                        exband = next((band for band in bands if band in query_band_set), 1)
+
+                        band_infile = infile + '+' + str(exband)
+                        processOBJ.updateParameter('from_', band_infile)
+                        processOBJ.updateParameter('to', outfile)
 
                     elif item == 'ctxevenodd':
                         label = pvl.load(infile)
@@ -148,24 +195,24 @@ def main():
                         label = pvl.load(infile)
                         Nline = label['IsisCube']['Core']['Dimensions']['Lines']
                         Nsample = label['IsisCube']['Core']['Dimensions']['Samples']
-                        Sfactor = scaleFactor(Nline, Nsample)
+                        Nline = int(Nline)
+                        Nsample = int(Nsample)
+                        Sfactor = scaleFactor(Nline, Nsample, recip_json)
                         processOBJ.updateParameter('lscale', Sfactor)
                         processOBJ.updateParameter('sscale', Sfactor)
                         processOBJ.updateParameter('from_', infile)
                         processOBJ.updateParameter('to', outfile)
 
                     elif item == 'isis2std':
-                        outfile = finalpath + '/' + \
-                            os.path.splitext(os.path.basename(inputfile))[
-                                0] + '.browse.jpg'
+                        final_outfile = finalpath + '/' + os.path.splitext(os.path.basename(inputfile))[0] + '.browse.jpg'
                         processOBJ.updateParameter('from_', infile)
-                        processOBJ.updateParameter('to', outfile)
+                        processOBJ.updateParameter('to', final_outfile)
 
                     else:
                         processOBJ.updateParameter('from_', infile)
                         processOBJ.updateParameter('to', outfile)
 
-                    print processOBJ.getProcess()
+                    print(processOBJ.getProcess())
 
                     for k, v in processOBJ.getProcess().items():
                         func = getattr(isis, k)
@@ -176,16 +223,19 @@ def main():
                                 if '.cub' in outfile:
                                     os.rename(outfile, infile)
                             status = 'success'
+                            if '2isis' in item:
+                                isisSerial = getISISid(infile)
                         except ProcessError as e:
                             logger.error('Process %s :: Error', k)
                             status = 'error'
-
-            if status == 'success':
+            if status == 'success': 
+                DB_addURL(upc_session, isisSerial, final_outfile)
                 os.remove(infile)
-                logger.info('Browse Process Success: %s', inputfile)
+                logger.info('Browse Process Success: %s', inputfile)  
+
+                AddProcessDB(pds_session, fid, 't')
         else:
             logger.error('File %s Not Found', inputfile)
-
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/pds_pipelines/thumbnail_process.py
+++ b/pds_pipelines/thumbnail_process.py
@@ -2,33 +2,43 @@
 import os
 import sys
 import pvl
+import json
+import datetime
+import pytz
 import logging
 from pysis import isis
 from pysis.exceptions import ProcessError
 
+from pysis.isis import getsn
+from ast import literal_eval
+
 from pds_pipelines.RedisQueue import *
 from pds_pipelines.Recipe import *
+from pds_pipelines.db import db_connect
+from pds_pipelines.models.upc_models import MetaString, DataFiles
+from pds_pipelines.models.pds_models import ProcessRuns, Files
+from pds_pipelines.config import pds_log_loc, pds_info_loc
 
 import pdb
 
+def getISISid(infile):
+    serial_num = getsn(from_=infile)
+    if isinstance(serial_num, bytes):
+        serial_num = serial_num.decode()
+    newisisSerial = serial_num.replace('\n', '')
+    return newisisSerial
 
-def scaleFactor(line, sample):
-    """
-    Parameters
-    ----------
-    line : int
-    sample : int
 
-    Returns
-    -------
-    int
-        scalefactor
-    """
+def scaleFactor(line, sample, jsonfile):
 
-    maxLine = 300
-    maxSample = 300
-    minLine = 50
-    minSample = 50
+#    pdb.set_trace()
+
+    infoDICT = json.load(open(jsonfile, 'r'))
+
+    maxLine = int(infoDICT['reduced']['thumbnail']['maxlines'])
+    maxSample = int(infoDICT['reduced']['thumbnail']['maxsamples'])
+    minLine = int(infoDICT['reduced']['thumbnail']['minlines'])
+    minSample = int(infoDICT['reduced']['thumbnail']['minsamples'])
 
     if sample < line:
         scalefactor = line/maxLine
@@ -40,94 +50,138 @@ def scaleFactor(line, sample):
     else:
         scalefactor = sample/maxSample
         testline = int(line/scalefactor)
-
+         
         if testline < minLine:
             scalefactor = line/minLine
 
+    if scalefactor < 1:
+        scalefactor = 1
     return scalefactor
 
 
 def makedir(inputfile):
-    """
-    Parameters
-    ----------
-    inputfile
-    
-    Returns
-    -------
-    str
-        finalpath
-    """
+#    pdb.set_trace()
 
     temppath = os.path.dirname(inputfile).lower()
-    finalpath = temppath.replace(
-        '/pds_san/pds_archive/', '/pds_san/PDS_Derived/UPC/images/')
+    finalpath = temppath.replace('/pds_san/pds_archive/', '/pds_san/PDS_Derived/UPC/images/')
 
     if not os.path.exists(finalpath):
         try:
-            os.makedirs(finalpath, 0755)
+            os.makedirs(finalpath, exist_ok=True)
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
 
     return finalpath
 
+def DB_addURL(session, isisSerial, inputfile):
+    # pdb.set_trace()
+    newisisSerial = isisSerial.split(':')[0]
+    likestr = '%' + newisisSerial + '%'
+    Qobj = session.query(datafiles).filter(datafiles.isisid.like(likestr)).first()
+
+    if str(Qobj.isisid) == str(isisSerial):
+
+        outputfile = inputfile.replace('/pds_san/PDS_Derived/UPC/images/', '$thumbnail_server/')
+
+        DBinput = meta_string(upcid=Qobj.upcid,
+                            typeid='348',
+                            value=outputfile)
+
+        try:
+            session.add(DBinput)
+            session.commit()
+            return 'SUCCESS'
+        except:
+            return 'ERROR'
+
+
+def AddProcessDB(session, fid, outvalue):
+    # pdb.set_trace()
+    date = datetime.datetime.now(pytz.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+    processDB = pds_models.ProcessRuns(fileid=fid,
+                             process_date=date,
+                             process_typeid='5',
+                             process_out=outvalue)
+
+    try:
+        session.merge(processDB)
+        session.commit()
+        return 'SUCCESS'
+    except:
+        return 'ERROR'
+
 
 def main():
 
-    #    pdb.set_trace()
+#    pdb.set_trace()
 
-    workarea = '/scratch/pds_services/workarea/'
+    # @TODO move to config file
+    workarea = '/home/arsanders/PDS-Pipelines/products/'
+    #workarea = '/scratch/pds_services/workarea/'
 
-# ***************** Set up logging *****************
+    ##***************** Set up logging *****************
     logger = logging.getLogger('Thumbnail_Process')
     logger.setLevel(logging.INFO)
-    logFileHandle = logging.FileHandler('/usgs/cdev/PDS/logs/Process.log')
-    formatter = logging.Formatter(
-        '%(asctime)s - %(name)s - %(levelname)s, %(message)s')
+    logFileHandle = logging.FileHandler(pds_log_loc + 'Process.log')
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s, %(message)s')
     logFileHandle.setFormatter(formatter)
-    logger.addHandler(logFileHandle)
+    logger.addHandler(logFileHandle)    
 
     RQ_main = RedisQueue('Thumbnail_ReadyQueue')
 
-    while int(RQ_main.QueueSize()) > 0:
+    PDSinfoDICT = json.load(open(pds_info_loc, 'r'))
 
-        inputfile = RQ_main.QueueGet()
+    # @TODO change to production servers
+    pds_session = db_connect('pdsdi_dev')
+    upc_session = db_connect('upcdev')
+
+    while int(RQ_main.QueueSize()) > 0:
+        item = literal_eval(RQ_main.QueueGet().decode("utf-8"))
+        inputfile = item[0]
+        fid = item[1]
+        archive = item[2]
         if os.path.isfile(inputfile):
             logger.info('Starting Process: %s', inputfile)
 
-            if 'Mars_Reconnaissance_Orbiter/CTX/' in inputfile:
-                mission = 'CTX'
-
-# ********** Derived DIR path Stuff **********************
-
-            finalpath = makedir(inputfile)
+            finalpath = makedir(inputfile)                  
 
             recipeOBJ = Recipe()
-            recip_json = recipeOBJ.getRecipeJSON(mission)
-            recipeOBJ.AddJsonFile(recip_json, 'pow')
-
-            infile = workarea + \
-                os.path.splitext(os.path.basename(inputfile))[
-                    0] + '.Tinput.cub'
-            outfile = workarea + \
-                os.path.splitext(os.path.basename(inputfile))[
-                    0] + '.Toutput.cub'
-
+            recip_json = recipeOBJ.getRecipeJSON(archive)
+            recipeOBJ.AddJsonFile(recip_json, 'reduced')
+            infile = workarea + os.path.splitext(os.path.basename(inputfile))[0] + '.Tinput.cub'
+            outfile = workarea + os.path.splitext(os.path.basename(inputfile))[0] + '.Toutput.cub'
             status = 'success'
             for item in recipeOBJ.getProcesses():
                 if status == 'error':
                     break
                 elif status == 'success':
                     processOBJ = Process()
-                    processR = processOBJ.ProcessFromRecipe(
-                        item, recipeOBJ.getRecipe())
+                    processR = processOBJ.ProcessFromRecipe(item, recipeOBJ.getRecipe())
 
                     if '2isis' in item:
                         processOBJ.updateParameter('from_', inputfile)
                         processOBJ.updateParameter('to', outfile)
                     elif item == 'spiceinit':
                         processOBJ.updateParameter('from_', infile)
+                    elif item == 'cubeatt':
+                        label = pvl.load(infile)
+                        bands = PDSinfoDICT[archive]['bandorder']
+                        query_bands = label['IsisCube']['BandBin'][PDSinfoDICT[archive]['bandbinQuery']]
+                        # Create a set from the list / single value
+                        try:
+                            query_band_set = set(query_bands)
+                        except:
+                            query_band_set = set([query_bands])
+                        
+                        # Iterate through 'bands' and grab the first value that is present in the
+                        #  set defined by 'bandbinquery' -- if not present, default to 1
+                        exband = next((band for band in bands if band in query_band_set), 1)
+
+                        band_infile = infile + '+' + str(exband)
+                        processOBJ.updateParameter('from_', band_infile)
+                        processOBJ.updateParameter('to', outfile)
 
                     elif item == 'ctxevenodd':
                         label = pvl.load(infile)
@@ -142,23 +196,24 @@ def main():
                         label = pvl.load(infile)
                         Nline = label['IsisCube']['Core']['Dimensions']['Lines']
                         Nsample = label['IsisCube']['Core']['Dimensions']['Samples']
-                        Sfactor = scaleFactor(Nline, Nsample)
+                        Nline = int(Nline)
+                        Nsample = int(Nsample)
+                        Sfactor = scaleFactor(Nline, Nsample, recip_json)
                         processOBJ.updateParameter('lscale', Sfactor)
                         processOBJ.updateParameter('sscale', Sfactor)
                         processOBJ.updateParameter('from_', infile)
                         processOBJ.updateParameter('to', outfile)
+
                     elif item == 'isis2std':
-                        outfile = finalpath + '/' + \
-                            os.path.splitext(os.path.basename(inputfile))[
-                                0] + '.thumbnail.jpg'
+                        final_outfile = finalpath + '/' + os.path.splitext(os.path.basename(inputfile))[0] + '.thumbnail.jpg'
                         processOBJ.updateParameter('from_', infile)
-                        processOBJ.updateParameter('to', outfile)
+                        processOBJ.updateParameter('to', final_outfile)
 
                     else:
                         processOBJ.updateParameter('from_', infile)
                         processOBJ.updateParameter('to', outfile)
 
-                    print processOBJ.getProcess()
+                    print(processOBJ.getProcess())
 
                     for k, v in processOBJ.getProcess().items():
                         func = getattr(isis, k)
@@ -169,16 +224,19 @@ def main():
                                 if '.cub' in outfile:
                                     os.rename(outfile, infile)
                             status = 'success'
+                            if '2isis' in item:
+                                isisSerial = getISISid(infile)
                         except ProcessError as e:
                             logger.error('Process %s :: Error', k)
                             status = 'error'
-
             if status == 'success':
+                testout = DB_addURL(upc_session, isisSerial, final_outfile)
                 os.remove(infile)
                 logger.info('Thumbnail Process Success: %s', inputfile)
+
+                AddProcessDB(pds_session, fid, 't')  
         else:
             logger.error('File %s Not Found', inputfile)
-
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/recipe/Keyword_Definition.json
+++ b/recipe/Keyword_Definition.json
@@ -586,7 +586,7 @@
         "keyword": "DATA_SET_ID"  
       }
     },
-    "themis_ir_edr": {
+    "mo_themis_ir_edr": {
       "gainnumber": {
         "type": "integer",
         "displayname": "Gain Number",

--- a/recipe/new/cassini_iss.json
+++ b/recipe/new/cassini_iss.json
@@ -96,7 +96,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/cassini_iss_ground_cal.json
+++ b/recipe/new/cassini_iss_ground_cal.json
@@ -50,7 +50,19 @@
                 "from_": "value",
                 "cknadir": "no"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/cassini_iss_maps.json
+++ b/recipe/new/cassini_iss_maps.json
@@ -50,7 +50,19 @@
                 "from_": "value",
                 "cknadir": "no"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/cassini_radar.json
+++ b/recipe/new/cassini_radar.json
@@ -50,7 +50,19 @@
                 "from_": "value",
                 "cknadir": "no"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/cassini_vims.json
+++ b/recipe/new/cassini_vims.json
@@ -85,7 +85,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/chandrayaan_m3.json
+++ b/recipe/new/chandrayaan_m3.json
@@ -84,7 +84,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/clementine.json
+++ b/recipe/new/clementine.json
@@ -79,7 +79,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/clementine_edr.json
+++ b/recipe/new/clementine_edr.json
@@ -79,7 +79,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/clementine_lwir.json
+++ b/recipe/new/clementine_lwir.json
@@ -79,7 +79,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/clementine_nir.json
+++ b/recipe/new/clementine_nir.json
@@ -70,7 +70,19 @@
                 "maxincidence": "120.0",
                 "spice": "no"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "55",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/clementine_nir_edr.json
+++ b/recipe/new/clementine_nir_edr.json
@@ -33,7 +33,19 @@
                 "from_": "value",
                 "to": "value"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/clementine_uvvis_edr.json
+++ b/recipe/new/clementine_uvvis_edr.json
@@ -29,7 +29,19 @@
                 "from_": "value",
                 "to": "value"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/dawn_ceres.json
+++ b/recipe/new/dawn_ceres.json
@@ -83,7 +83,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/dawn_vesta.json
+++ b/recipe/new/dawn_vesta.json
@@ -83,7 +83,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/galileo_ssi_edr.json
+++ b/recipe/new/galileo_ssi_edr.json
@@ -95,7 +95,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/lro_lroc_edr.json
+++ b/recipe/new/lro_lroc_edr.json
@@ -93,7 +93,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/lro_lroc_edr_nac.json
+++ b/recipe/new/lro_lroc_edr_nac.json
@@ -93,7 +93,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mariner_10.json
+++ b/recipe/new/mariner_10.json
@@ -92,7 +92,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mars_express.json
+++ b/recipe/new/mars_express.json
@@ -93,7 +93,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mars_express_rdr.json
+++ b/recipe/new/mars_express_rdr.json
@@ -93,7 +93,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/messenger.json
+++ b/recipe/new/messenger.json
@@ -95,7 +95,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/messenger_edr.json
+++ b/recipe/new/messenger_edr.json
@@ -95,7 +95,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/messenger_mission.json
+++ b/recipe/new/messenger_mission.json
@@ -80,7 +80,19 @@
                 "spkrecon": "yes",
                 "spkpredicted": "yes"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mgs_compressed_sdp.json
+++ b/recipe/new/mgs_compressed_sdp.json
@@ -79,7 +79,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mgs_decompressed_sdp.json
+++ b/recipe/new/mgs_decompressed_sdp.json
@@ -80,7 +80,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mgs_moc.json
+++ b/recipe/new/mgs_moc.json
@@ -37,7 +37,19 @@
                 "from_": "value",
                 "to": "value"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mgs_moc_na.json
+++ b/recipe/new/mgs_moc_na.json
@@ -37,7 +37,19 @@
                 "from_": "value",
                 "to": "value"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mgs_moc_wa.json
+++ b/recipe/new/mgs_moc_wa.json
@@ -37,7 +37,19 @@
                 "from_": "value",
                 "to": "value"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mo_themis_ODTSDP_V1.json
+++ b/recipe/new/mo_themis_ODTSDP_V1.json
@@ -83,7 +83,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mo_themis_ODTSDP_V1_vis.json
+++ b/recipe/new/mo_themis_ODTSDP_V1_vis.json
@@ -85,7 +85,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mo_themis_ir_btr.json
+++ b/recipe/new/mo_themis_ir_btr.json
@@ -70,7 +70,19 @@
                 "maxincidence": "120.0",
                 "spice": "no"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mo_themis_ir_edr.json
+++ b/recipe/new/mo_themis_ir_edr.json
@@ -83,7 +83,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mo_themis_ir_geo.json
+++ b/recipe/new/mo_themis_ir_geo.json
@@ -50,7 +50,19 @@
                 "from_": "value",
                 "cknadir": "yes"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mo_themis_vis_edr.json
+++ b/recipe/new/mo_themis_vis_edr.json
@@ -89,7 +89,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mro_ctx.json
+++ b/recipe/new/mro_ctx.json
@@ -100,7 +100,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mro_hirise.json
+++ b/recipe/new/mro_hirise.json
@@ -79,7 +79,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mro_hirise_edr.json
+++ b/recipe/new/mro_hirise_edr.json
@@ -79,7 +79,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mro_hirise_edr_aeb.json
+++ b/recipe/new/mro_hirise_edr_aeb.json
@@ -79,7 +79,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mro_hirise_edr_esp.json
+++ b/recipe/new/mro_hirise_edr_esp.json
@@ -79,7 +79,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mro_hirise_edr_psp.json
+++ b/recipe/new/mro_hirise_edr_psp.json
@@ -79,7 +79,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mro_hirise_edr_tra.json
+++ b/recipe/new/mro_hirise_edr_tra.json
@@ -79,7 +79,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mro_hirise_rdr.json
+++ b/recipe/new/mro_hirise_rdr.json
@@ -39,7 +39,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "100",
+	    "minsamples": "100",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mro_hirise_rdr_esp.json
+++ b/recipe/new/mro_hirise_rdr_esp.json
@@ -39,7 +39,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "100",
+	    "minsamples": "100",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mro_hirise_rdr_psp.json
+++ b/recipe/new/mro_hirise_rdr_psp.json
@@ -39,7 +39,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "100",
+	    "minsamples": "100",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/mro_marci.json
+++ b/recipe/new/mro_marci.json
@@ -85,7 +85,19 @@
                 "minpercent": "0.0",
                 "maxpercent": "100.0"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/viking_orbiter_edr.json
+++ b/recipe/new/viking_orbiter_edr.json
@@ -99,7 +99,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/voyager.json
+++ b/recipe/new/voyager.json
@@ -79,7 +79,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/voyager_jupiter.json
+++ b/recipe/new/voyager_jupiter.json
@@ -79,7 +79,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/voyager_neptune.json
+++ b/recipe/new/voyager_neptune.json
@@ -79,7 +79,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/voyager_saturn.json
+++ b/recipe/new/voyager_saturn.json
@@ -79,7 +79,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {

--- a/recipe/new/voyager_uranus.json
+++ b/recipe/new/voyager_uranus.json
@@ -79,7 +79,19 @@
                 "quality": "60",
                 "stretch": "linear"
             }
-        }
+        },
+	"browse": {
+	    "minlines": "200",
+	    "minsamples": "200",
+	    "maxlines": "900",
+	    "maxsamples": "900"
+	},
+	"thumbnail": {
+	    "minlines": "50",
+	    "minsamples": "50",
+	    "maxlines": "300",
+	    "maxsamples": "300"
+	}
     },
     "projected": {
         "recipe": {


### PR DESCRIPTION
Addresses #87 

When a user specifies a non-existent or misspelled archive, the program now returns an error message stating the path of the pdsinfo.json file being used and the names of all archives that are contained in the json file.

This should help users to continue using the command line utilities despite the recent re-keying of the pdsinfo file.