### PR TITLE
Updated mo_themis_vis_edr keywords

### DIFF
--- a/recipe/Keyword_Definition.json
+++ b/recipe/Keyword_Definition.json
@@ -977,6 +977,204 @@
 		"group": "BandBin",
 		"keyword": "Center"
 	    },
+	        "percentlrs": {
+                "type": "double",
+                "displayname": "Percent LRS Pixels",
+        	"group": "Statistics",
+                "keyword": "PercentLRS"
+            },
+            "missionname": {
+                "type": "string",
+                "displayname": "MISSION_NAME",
+        	"group": "OriginalLabel",
+                "keyword": "MISSION_NAME"
+            },
+            "instrumentid": {
+                "type": "string",
+                "displayname": "Instrument Identifier",
+        	"group": "Instrument",
+                "keyword": "InstrumentId"
+            },
+            "dnminimum": {
+                "type": "double",
+                "displayname": "Data Minimum",
+	        "group": "Statistics",
+                "keyword": "MinimumValue"
+            },
+            "instrumenthostname": {
+                "type": "string",
+                "displayname": "INSTRUMENT_HOST_NAME",
+	        "group": "OriginalLabel",
+                "keyword": "INSTRUMENT_HOST_NAME"
+            },
+            "percentnull": {
+                "type": "double",
+                "displayname": "Percent NULL Pixels",
+	        "group": "Statistics",
+                "keyword": "PercentNull"
+            },
+            "percenthis": {
+                "type": "double",
+                "displayname": "Percent HIS Pixels",
+	        "group": "Statistics",
+                "keyword": "PercentHIS"
+            },
+            "detectorid": {
+                "type": "string",
+                "displayname": "DETECTOR_ID",
+	        "group": "OriginalLabel",
+                "keyword": "DETECTOR_ID"
+            },
+            "spacecraftname": {
+                "type": "string",
+                "displayname": "Spacecraft Name",
+	        "group": "Instrument",
+                "keyword": "SpacecraftName"
+            },
+            "imageduration": {
+                "type": "double",
+                "displayname": "IMAGE_DURATION",
+	        "group": "OriginalLabel",
+                "keyword": "IMAGE_DURATION"
+            },
+            "percenthrs": {
+                "type": "double",
+                "displayname": "Percent HRS Pixels",
+	        "group": "Statistics",
+                "keyword": "PercentHRS"
+            },
+            "dnmaximum": {
+                "type": "double",
+                "displayname": "Data Maximum",
+        	"group": "Statistics",
+                "keyword": "MaximumValue"
+            },
+            "producerid": {
+                "type": "string",
+                "displayname": "PRODUCER_ID",
+        	"group": "Archive",
+                "keyword": "ProducerId"
+            },
+            "flightsoftwareversionid": {
+                "type": "string",
+                "displayname": "FLIGHT_SOFTWARE_VERSION_ID",
+        	"group": "Archive",
+                "keyword": "FlightSoftwareVersionId"
+            },
+            "interframedelay": {
+                "type": "double",
+                "displayname": "INTERFRAME_DELAY",
+        	"group": "Instrument",
+                "keyword": "InterframeDelay"
+            },
+            "datasetid": {
+                "type": "string",
+                "displayname": "DATA_SET_ID",
+        	"group": "Archive",
+                "keyword": "DataSetId"
+            },
+            "coreunit": {
+                "type": "string",
+                "displayname": "CORE_UNIT",
+	        "group": "OriginalLabel",
+                "keyword": "CORE_UNIT"
+            },
+            "totalpixels": {
+                "type": "double",
+                "displayname": "Total Pixels",
+	        "group": "Statistics",
+                "keyword": "TotalPixels"
+            },
+            "productcreationtime": {
+                "type": "time",
+                "displayname": "PRODUCT_CREATION_TIME",
+        	"group": "Archive",
+                "keyword": "ProductCreationTime"
+            },
+            "stoptimeet": {
+                "type": "string",
+                "displayname": "STOP_TIME_ET",
+        	"group": "OriginalLabel",
+                "keyword": "STOP_TIME_ET"
+            },
+            "spacecraftclockstopcount": {
+                "type": "string",
+                "displayname": "SPACECRAFT_CLOCK_STOP_COUNT",
+        	"group": "OriginalLabel",
+                "keyword": "SPACECRAFT_CLOCK_STOP_COUNT"
+            },
+            "stddev": {
+                "type": "double",
+                "displayname": "Standard Deviation",
+        	"group": "Statistics",
+                "keyword": "StandardDeviation"
+            },
+            "corename": {
+                "type": "string",
+                "displayname": "CORE_NAME",
+        	"group": "CORE_NAME",
+                "keyword": "OriginalLabel"
+            },
+            "imageid": {
+                "type": "integer",
+                "displayname": "IMAGE_ID",
+        	"group": "OriginalLabel",
+                "keyword": "IMAGE_ID"
+            },
+            "instrcmprsratio": {
+                "type": "double",
+                "displayname": "INST_COMPRS_RATIO",
+        	"group": "OriginalLabel",
+                "keyword": "INST_COMPRS_RATIO"
+            },
+            "instrcmprsname": {
+                "type": "string",
+                "displayname": "INST_COMPRS_NAME",
+        	"group": "OriginalLabel",
+                "keyword": "INST_COMPRS_NAME"
+            },
+            "md5checksum": {
+                "type": "string",
+                "displayname": "MD5_CHECKSUM",
+        	"group": "OriginalLabel",
+                "keyword": "MD5_CHECKSUM"
+            },
+            "mean": {
+                "type": "double",
+                "displayname": "Mean (Average)",
+        	"group": "Statistics",
+                "keyword": "MeanValue"
+            },
+            "percentlis": {
+                "type": "double",
+                "displayname": "Percent LIS Pixels",
+        	"group": "Statistics",
+                "keyword": "PercentLIS"
+            },
+            "releaseid": {
+                "type": "string",
+                "displayname": "RELEASE_ID",
+        	"group": "OriginalLabel",
+                "keyword": "RELEASE_ID"
+            },
+            "commandsequencenumber": {
+                "type": "integer",
+                "displayname": "COMMAND_SEQUENCE_NUMBER",
+        	"group": "OriginalLabel",
+                "keyword": "COMMAND_SEQUENCE_NUMBER"
+            },
+            "starttimeet": {
+                "type": "string",
+                "displayname": "START_TIME_ET",
+        	"group": "OriginalLabel",
+                "keyword": "START_TIME_ET"
+            },
+            "uncorrectedsclkstartcount": {
+                "type": "string",
+                "displayname": "UNCORRECTED_SCLK_START_COUNT",
+        	"group": "OriginalLabel",
+                "keyword": "UNCORRECTED_SCLK_START_COUNT"
+            },
             "productversionid": {
                 "type": "double",
                 "displayname": "Product Version ID",


### PR DESCRIPTION
Updated `recipe/Keyword_Definition.json` additional fields for `mo_themis_vis_edr`. This should better reflect the fields in the production database for THEMIS VIS products. 

One caveat:
The database has a field called "observationid" but there doesn't appear to be a corresponding keyword anywhere in THEMIS VIS product labels. The field has been omitted from the updates in this PR.