### PR TITLE
Increase wall time limits in Service/Final Jobbers to 24 hours

### DIFF
--- a/pds_pipelines/FinalJobber.py
+++ b/pds_pipelines/FinalJobber.py
@@ -47,7 +47,7 @@ def main():
         jobOBJ.setJobName(FKey + '_Final')
         jobOBJ.setStdOut('/usgs/cdev/PDS/output/' + FKey + '_%A_%a.out')
         jobOBJ.setStdError('/usgs/cdev/PDS/output/' + FKey + '_%A_%a.err')
-        jobOBJ.setWallClock('05:00:00')
+        jobOBJ.setWallClock('24:00:00')
         jobOBJ.setMemory('8192')
         jobOBJ.setPartition('pds')
 

--- a/pds_pipelines/Servicejobber.py
+++ b/pds_pipelines/Servicejobber.py
@@ -912,7 +912,7 @@ def main():
     jobOBJ.setJobName(Key + '_Service')
     jobOBJ.setStdOut('/usgs/cdev/PDS/output/' + Key + '_%A_%a.out')
     jobOBJ.setStdError('/usgs/cdev/PDS/output/' + Key + '_%A_%a.err')
-    jobOBJ.setWallClock('10:00:00')
+    jobOBJ.setWallClock('24:00:00')
 #    jobOBJ.setMemory('8192')
 #    jobOBJ.setMemory('16384')
     jobOBJ.setMemory('24576')


### PR DESCRIPTION
At some point we "unofficially" increased the SLURM wall time limits to 24 hours in `Servicejobber.py` and `FinalJobber.py` but these updates were never committed and pushed. This PR formally adds those changes.