### PR TITLE
Initial RedisLock.py

### DIFF
--- a/pds_pipelines/DIprocess.py
+++ b/pds_pipelines/DIprocess.py
@@ -15,7 +15,7 @@ from pds_pipelines.PDS_DBquery import *
 
 from sqlalchemy import *
 from sqlalchemy.orm.util import *
-from pds_pipelines.config import pds_db, pds_log, pds_info
+from pds_pipelines.config import pds_db, pds_log, pds_info, lock_obj
 from pds_pipelines.db import db_connect
 from pds_pipelines.models.pds_models import Files
 
@@ -45,7 +45,7 @@ def main():
         logger.error('DataBase Connection: Error')
 
     RQ = RedisQueue('DI_ReadyQueue')
-    RQ_lock = RedisLock('processes')
+    RQ_lock = RedisLock(lock_obj)
     RQ_lock.add({RQ.id_name: '1'})
     index = 0
 

--- a/pds_pipelines/IngestProcess.py
+++ b/pds_pipelines/IngestProcess.py
@@ -18,7 +18,7 @@ from pds_pipelines.RedisQueue import RedisQueue
 from pds_pipelines.RedisLock import RedisLock
 from pds_pipelines.PDS_DBquery import *
 from pds_pipelines.db import db_connect
-from pds_pipelines.config import pds_info, pds_log, pds_db, archive_base, web_base
+from pds_pipelines.config import pds_info, pds_log, pds_db, archive_base, web_base, lock_obj
 from pds_pipelines.models.pds_models import Files
 
 
@@ -56,7 +56,7 @@ def main():
     PDSinfoDICT = json.load(open(pds_info, 'r'))
 
     RQ_main = RedisQueue('Ingest_ReadyQueue')
-    RQ_lock = RedisLock('processes')
+    RQ_lock = RedisLock(lock_obj)
     RQ_lock.add({RQ_main.id_name: '1'})
     RQ_work = RedisQueue('Ingest_WorkQueue')
 

--- a/pds_pipelines/MAPprocess.py
+++ b/pds_pipelines/MAPprocess.py
@@ -10,7 +10,9 @@ from pysis import isis
 from pysis.exceptions import ProcessError
 from pysis.isis import map2map
 
-from pds_pipelines.RedisQueue import *
+from pds_pipelines.config import lock_obj
+from pds_pipelines.RedisQueue import RedisQueue
+from pds_pipelines.RedisLock import RedisLock
 from pds_pipelines.RedisHash import *
 from pds_pipelines.Recipe import *
 from pds_pipelines.Loggy import *
@@ -35,8 +37,10 @@ def main():
     RQ_final = RedisQueue('FinalQueue')
     RHash = RedisHash(Key + '_info')
     RHerror = RedisHash(Key + '_error')
+    RQ_lock = RedisLock(lock_obj)
+    RQ_lock.add({'MAP':'1'})
 
-    if int(RQ_file.QueueSize()) == 0:
+    if int(RQ_file.QueueSize()) == 0 and RQ_lock.available('MAP'):
         print "No Files Found in Redis Queue"
     else:
         jobFile = RQ_file.Qfile2Qwork(

--- a/pds_pipelines/POWprocess.py
+++ b/pds_pipelines/POWprocess.py
@@ -11,6 +11,7 @@ from pysis import isis
 from pysis.exceptions import ProcessError
 
 from pds_pipelines.RedisQueue import RedisQueue
+from pds_pipelines.RedisLock import RedisLock
 from pds_pipelines.RedisHash import RedisHash
 from pds_pipelines.Process import Process
 from pds_pipelines.Loggy import Loggy
@@ -34,11 +35,9 @@ def main():
     RHerror = RedisHash(Key + '_error')
 
     if int(RQ_file.QueueSize()) == 0:
-
-        print "No Files Found in Redis Queue"
-
+        print("No Files Found in Redis Queue")
     else:
-        print RQ_file.getQueueName()
+        print(RQ_file.getQueueName())
         jobFile = RQ_file.Qfile2Qwork(
             RQ_file.getQueueName(), RQ_work.getQueueName())
 
@@ -82,7 +81,7 @@ def main():
                 process = processOBJ.JSON2Process(element)
 
                 if 'gdal_translate' not in processOBJ.getProcessName():
-                    print processOBJ.getProcessName()
+                    print(processOBJ.getProcessName())
                     if '2isis' in processOBJ.getProcessName():
                         processOBJ.updateParameter('from_', inputFile)
                         processOBJ.updateParameter('to', outfile)
@@ -109,7 +108,7 @@ def main():
                     elif 'ctxevenodd' in processOBJ.getProcessName():
                         label = pvl.load(infile)
                         SS = label['IsisCube']['Instrument']['SpatialSumming']
-                        print SS
+                        print(SS)
                         if SS != 1:
                             continue
                         else:
@@ -119,7 +118,7 @@ def main():
                     elif 'mocevenodd' in processOBJ.getProcessName():
                         label = pvl.load(infile)
                         CTS = label['IsisCube']['Instrument']['CrosstrackSumming']
-                        print CTS
+                        print(CTS)
                         if CTS != 1:
                             continue
                         else:
@@ -201,7 +200,7 @@ def main():
                         processOBJ.updateParameter('from_', infile)
                         processOBJ.updateParameter('to', outfile)
 
-                    print processOBJ.getProcess()
+                    print(processOBJ.getProcess())
 
                     for k, v in processOBJ.getProcess().items():
                         func = getattr(isis, k)
@@ -256,7 +255,7 @@ def main():
                     finalfile = infile.replace(
                         '.input.cub', '_final.' + fileext)
                     GDALcmd += ' ' + infile + ' ' + finalfile
-                    print GDALcmd
+                    print(GDALcmd)
 
                     result = subprocess.call(GDALcmd, shell=True)
                     if result == 0:

--- a/pds_pipelines/POWprocess.py
+++ b/pds_pipelines/POWprocess.py
@@ -10,6 +10,8 @@ import shutil
 from pysis import isis
 from pysis.exceptions import ProcessError
 
+from pds_pipelines.config import lock_obj
+from pds_pipelines.RedisLock import RedisLock
 from pds_pipelines.RedisQueue import RedisQueue
 from pds_pipelines.RedisLock import RedisLock
 from pds_pipelines.RedisHash import RedisHash
@@ -33,8 +35,10 @@ def main():
     RQ_final = RedisQueue('FinalQueue')
     RHash = RedisHash(Key + '_info')
     RHerror = RedisHash(Key + '_error')
+    RQ_lock = Redislock(lock_obj)
+    RQ_lock.add({'POW':'1'})
 
-    if int(RQ_file.QueueSize()) == 0:
+    if int(RQ_file.QueueSize()) == 0 and RQ_lock.available('POW'):
         print("No Files Found in Redis Queue")
     else:
         print(RQ_file.getQueueName())

--- a/pds_pipelines/RedisLock.py
+++ b/pds_pipelines/RedisLock.py
@@ -17,7 +17,8 @@ class RedisLock(object):
         name : str
           The name of the RedisLock object
         """
-        self._db = redis.StrictRedis(host=ri['host'], port=ri['port'], db=ri['db'])
+        #self._db = redis.StrictRedis(host=ri['host'], port=ri['port'], db=ri['db'])
+        self._db = redis.StrictRedis()
         self.name = 'lock:%s' % (name)
 
 
@@ -96,7 +97,8 @@ class RedisLock(object):
         -------
         None
         """
-        self._db.hset(self.name, key, value)
+        if self.contains(key):
+            self._db.hset(self.name, key, value)
 
 
     def get(self, key):

--- a/pds_pipelines/RedisLock.py
+++ b/pds_pipelines/RedisLock.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python
+
+import redis
+from pds_pipelines.config import redis_info as ri
+
+class RedisLock(object):
+    """A single-point of access 'lock' for Redis Queues
+
+    
+
+    """
+
+    def __init__(self, name):
+        """
+        Parameters
+        ----------
+        name : str
+          The name of the RedisLock object
+        """
+        self._db = redis.StrictRedis(host=ri['host'], port=ri['port'], db=ri['db'])
+        self.name = 'lock:%s' % (name)
+
+
+    def contains(self, key):
+        """ Test if a key exists in the hash map.
+        Parameters
+        ----------
+        element : str
+            The key for which the function will search
+        
+        Returns
+        -------
+        bool
+            True if the key exists in the hash map, otherwise False
+        """
+        return self._db.hexists(self.name, key)
+
+
+    def add(self, item):
+        """ Adds a key : value pair to the hash map.
+        Parameters
+        ----------
+        item : dict
+            A key value pair to be added to the hash map.
+        
+        Returns
+        -------
+        None
+        """
+        # Only allows for registry in an unlocked queue.
+        try:
+            if not self.get(next(iter(item))) == '0':
+                self._db.hmset(self.name, item)
+        except AttributeError:
+            self._db.hmset(self.name, item)
+
+
+    def remove(self, key):
+        """ Removes a key : value pair from the hash map.
+        Parameters
+        ----------
+        key : str
+            The key to be removed from the hash map.
+
+        Returns
+        -------
+        None
+        """
+        self._db.hdel(key)
+
+
+    def delete(self):
+        """ Removes the underlying hash map from the Redis DB.
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        None
+        """
+        self._db.delete(name)
+
+
+    def _set(self, key, value):
+        """ Sets the value in the key : value pair.
+        
+        Parameters
+        ----------
+        key : str
+            The key that will be added to the hash map
+        value : obj
+            The value associated with the key
+        
+        Returns
+        -------
+        None
+        """
+        self._db.hset(self.name, key, value)
+
+
+    def get(self, key):
+        """ Returns the value given a key.
+
+        Automatically decodes byte strings returned by Redis.
+
+        Parameters
+        ----------
+        key : str
+            The key associated with the value to be returned
+        
+        Returns
+        -------
+        str
+            The value associated with the specified key.
+        """
+        return (self._db.hget(self.name, key)).decode('utf-8')
+
+
+    def get_all(self):
+        """ Convenience function that returns a dict of all.
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        dict
+            The dictionary of all key:value pairs in the hash map.
+        """
+        return self._db.hgetall(self.name)
+
+
+    def lock(self, key):
+        """ Locks processing for the provided queue.
+        Parameters
+        ----------
+        key : str
+            The name of the queue that we wish to lock
+        
+        Returns
+        -------
+        None
+        """
+        self._set(key, '0')
+
+
+    def stop(self, key):
+        """
+        Parameters
+        ----------
+        key : str
+            The name of the queue that we wish to lock
+        
+        Returns
+        -------
+        None
+
+        """
+        self._set(key, '2')
+
+
+    def unlock(self, key):
+        """
+        Parameters
+        ----------
+        key : str
+            The name of the queue that we wish to unlock
+        
+        Returns
+        -------
+        None
+        """
+
+        self._set(key, '1')
+
+
+    def lock_all(self):
+        """ A convenience function that locks all queues in the hash map.
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        None
+        """
+        for key in self.get_all():
+            self.lock(key)
+
+
+    def stop_all(self):
+        """ A convenience function that stops processing for all queues in
+        the hash map.
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        None
+        """
+        for key in self.get_all():
+            self.stop(key)
+
+
+    def unlock_all(self):
+        """ A convenience function that unlocks all queues in the hash map.
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        None
+        """
+
+        for key in self.get_all():
+            self.unlock(key)
+
+
+    def available(self, key):
+        """
+        Parameters
+        ----------
+        key : str
+            The key to be tested for locked/unlocked status.
+        
+        Returns
+        -------
+        bool
+            True if the associated queue is unlocked, else False
+        """
+        return self.get(key) == '1'

--- a/pds_pipelines/RedisLock.py
+++ b/pds_pipelines/RedisLock.py
@@ -17,8 +17,7 @@ class RedisLock(object):
         name : str
           The name of the RedisLock object
         """
-        #self._db = redis.StrictRedis(host=ri['host'], port=ri['port'], db=ri['db'])
-        self._db = redis.StrictRedis()
+        self._db = redis.StrictRedis(host=ri['host'], port=ri['port'], db=ri['db'])
         self.name = 'lock:%s' % (name)
 
 

--- a/pds_pipelines/UPC_process.py
+++ b/pds_pipelines/UPC_process.py
@@ -22,7 +22,7 @@ from pds_pipelines.UPCkeywords import UPCkeywords
 from pds_pipelines.db import db_connect
 from pds_pipelines.models import upc_models, pds_models
 from pds_pipelines.models.upc_models import MetaTime, MetaGeometry, MetaString, MetaBoolean
-from pds_pipelines.config import pds_log, pds_info, workarea, keyword_def, pds_db, upc_db
+from pds_pipelines.config import pds_log, pds_info, workarea, keyword_def, pds_db, upc_db, lock_obj
 
 from sqlalchemy import and_
 
@@ -118,7 +118,7 @@ def main():
 
     # Redis Queue Objects
     RQ_main = RedisQueue('UPC_ReadyQueue')
-    RQ_lock = RedisLock('processes')
+    RQ_lock = RedisLock(lock_obj)
     # If the queue isn't registered, add it and set it to "running"
     RQ_lock.add({RQ_main.id_name: '1'})
 

--- a/pds_pipelines/browse_process.py
+++ b/pds_pipelines/browse_process.py
@@ -14,6 +14,7 @@ from pysis.exceptions import ProcessError
 from pysis.isis import getsn
 
 from pds_pipelines.RedisQueue import RedisQueue
+from pds_pipelines.RedisLock import RedisLock
 from pds_pipelines.Recipe import Recipe
 from pds_pipelines.Process import Process
 from pds_pipelines.db import db_connect
@@ -128,15 +129,17 @@ def main():
     logger.addHandler(logFileHandle)    
 
     RQ_main = RedisQueue('Browse_ReadyQueue')
+    RQ_lock = RedisLock('processes')
+    RQ_lock.add({RQ_main.id_name: '1'})
 
     PDSinfoDICT = json.load(open(pds_info, 'r'))
 
-    pds_session, _ = db_connect(pds_db)
-    upc_session, _ = db_connect(upc_db)
+    pds_session, pds_engine = db_connect(pds_db)
+    upc_session, upc_engine = db_connect(upc_db)
 
     tid = get_tid('fullimageurl', upc_session)
 
-    while int(RQ_main.QueueSize()) > 0:
+    while int(RQ_main.QueueSize()) > 0 and RQ_lock.available(RQ_main.id_name):
         item = literal_eval(RQ_main.QueueGet().decode("utf-8"))
         inputfile = item[0]
         fid = item[1]
@@ -234,6 +237,11 @@ def main():
                 AddProcessDB(pds_session, fid, 't')
         else:
             logger.error('File %s Not Found', inputfile)
+
+    upc_session.close()
+    pds_session.close()
+    upc_engine.dispose()
+    pds_engine.dispose()
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/pds_pipelines/browse_process.py
+++ b/pds_pipelines/browse_process.py
@@ -20,7 +20,7 @@ from pds_pipelines.Process import Process
 from pds_pipelines.db import db_connect
 from pds_pipelines.models.upc_models import MetaString, DataFiles
 from pds_pipelines.models.pds_models import ProcessRuns
-from pds_pipelines.config import pds_log, pds_info, workarea, pds_db, upc_db
+from pds_pipelines.config import pds_log, pds_info, workarea, pds_db, upc_db, lock_obj
 from pds_pipelines.UPC_process import get_tid
 
 def getISISid(infile):
@@ -129,7 +129,7 @@ def main():
     logger.addHandler(logFileHandle)    
 
     RQ_main = RedisQueue('Browse_ReadyQueue')
-    RQ_lock = RedisLock('processes')
+    RQ_lock = RedisLock(lock_obj)
     RQ_lock.add({RQ_main.id_name: '1'})
 
     PDSinfoDICT = json.load(open(pds_info, 'r'))

--- a/pds_pipelines/lock_queue.py
+++ b/pds_pipelines/lock_queue.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+from pds_pipelines.RedisLock import RedisLock
+from pds_pipelines.config import lock_obj
+import argparse
+
+
+class Args:
+    def __init__(self):
+        pass
+
+    def parse_args(self):
+        parser = argparse.ArgumentParser(description="Process / Queue locking tool")
+        parser.add_argument('action', choices=['lock', 'unlock', 'stop'], type=str.lower, help="The action to be performed on the queue", nargs='?')
+        parser.add_argument('queue', help="The queue to be locked/unlocked/stopped.", nargs='?')
+        parser.add_argument('--status', help="Display the status of all queues", action='store_true')
+
+        args=parser.parse_args()
+        self.action = args.action
+        self.target = args.queue
+        self.status = args.status
+
+
+# Map code to human-readable status
+status_map = {'0': 'locked', '1': 'unlocked', '2': 'stopped'}
+
+
+def main():
+    redis_lock = RedisLock(lock_obj)
+    args = Args()
+    args.parse_args()
+
+    if args.status:
+        print()
+        for k, v in redis_lock.get_all().items():
+            print("{}:\t{}".format(k.decode('utf-8'), status_map[v.decode('utf-8')]))
+        print()
+        return
+
+    # Inclusion of 'status' operator forces positional arguments to be optional even though they
+    #  are conceptually required.  Make sure that they are specified.
+    if args.action is None or args.target is None:
+        return
+
+    action = args.action
+    target = args.target.lower()
+
+    if target == 'all':
+        action += '_all'
+        target = None
+    else:
+        target = {'key':target}
+
+    func = getattr(redis_lock, action)
+
+    # if kwargs exist pass kwargs else pass empty param set
+    #  Allows for parameterization of foo(required_param) and bar().
+    func(**(target or {}))
+    
+
+if __name__ == "__main__":
+    main()

--- a/pds_pipelines/thumbnail_process.py
+++ b/pds_pipelines/thumbnail_process.py
@@ -13,6 +13,7 @@ from pysis.isis import getsn
 from ast import literal_eval
 
 from pds_pipelines.RedisQueue import RedisQueue
+from pds_pipelines.RedisLock import RedisLock
 from pds_pipelines.Recipe import Recipe
 from pds_pipelines.Process import Process
 from pds_pipelines.db import db_connect
@@ -120,7 +121,7 @@ def main():
 
 #    pdb.set_trace()
 
-    ##***************** Set up logging *****************
+    # Set up logging 
     logger = logging.getLogger('Thumbnail_Process')
     logger.setLevel(logging.INFO)
     logFileHandle = logging.FileHandler(pds_log + 'Process.log')
@@ -129,16 +130,17 @@ def main():
     logger.addHandler(logFileHandle)    
 
     RQ_main = RedisQueue('Thumbnail_ReadyQueue')
+    RQ_lock = RedisLock('processes')
+    RQ_lock.add({RQ_main.id_name: '1'})
 
     PDSinfoDICT = json.load(open(pds_info, 'r'))
 
-    # @TODO change to production servers
-    pds_session, _ = db_connect(pds_db)
-    upc_session, _ = db_connect(upc_db)
+    pds_session, pds_session = db_connect(pds_db)
+    upc_session, upc_session = db_connect(upc_db)
 
     tid = get_tid('thumbnailurl', upc_session)
 
-    while int(RQ_main.QueueSize()) > 0:
+    while int(RQ_main.QueueSize()) > 0 and RQ_lock.available(RQ_main.id_name):
         item = literal_eval(RQ_main.QueueGet().decode("utf-8"))
         inputfile = item[0]
         fid = item[1]
@@ -238,5 +240,11 @@ def main():
         else:
             logger.error('File %s Not Found', inputfile)
 
+    # Close all database connections
+    pds_session.close()
+    upc_session.close()
+    pds_engine.dispose()
+    upc_engine.dispose()
+    
 if __name__ == "__main__":
     sys.exit(main())

--- a/pds_pipelines/thumbnail_process.py
+++ b/pds_pipelines/thumbnail_process.py
@@ -19,7 +19,7 @@ from pds_pipelines.Process import Process
 from pds_pipelines.db import db_connect
 from pds_pipelines.models.upc_models import MetaString, DataFiles
 from pds_pipelines.models.pds_models import ProcessRuns
-from pds_pipelines.config import pds_log, pds_info, workarea, pds_db, upc_db
+from pds_pipelines.config import pds_log, pds_info, workarea, pds_db, upc_db, lock_obj
 from pds_pipelines.UPC_process import get_tid
 
 def getISISid(infile):
@@ -130,7 +130,7 @@ def main():
     logger.addHandler(logFileHandle)    
 
     RQ_main = RedisQueue('Thumbnail_ReadyQueue')
-    RQ_lock = RedisLock('processes')
+    RQ_lock = RedisLock(lock_obj)
     RQ_lock.add({RQ_main.id_name: '1'})
 
     PDSinfoDICT = json.load(open(pds_info, 'r'))


### PR DESCRIPTION
RedisLock is a prototype object that could be used in #52.  Instead of having independent Redis Keys (one per queue), the RedisLock object will serve as a single point of access locking hub.  It uses an underlying hash table where keys are the names of redis queues that will be locked / unlocked.  Values are simply "0" or "1" -- 0 being locked, 1 being unlocked.  Currently, we can lock/unlock individual queues or lock/unlock all queues at once, but it may be worthwhile to be able to control queues by namespace as well, e.g. RL.lock_all(prefix='test_queue').

It should be made clear that locking a queue doesn't actually affect the associated queues.  If a script doesn't honor the locking mechanism, then the RedisLock makes no difference.  The idea here is that when a script connects to a RedisQueue, it will also register in the RedisLock and observe the values on its own.  The syntax would be as follows:

```
# Connect to the main queue
rq_main = RedisQueue('UPC_ReadyQueue')
# Connect to the RedisLock
rq_lock = RedisQueue('processes')
# Register process name (including namespace) in RedisLock
rq_lock.add({rq_main.name: '1'})

# Continue to do stuff until queue is empty or until the queue is locked
while rq_main.QueueSize() > 0 and rq_lock.available(rq_main.name):
    do_stuff()
```

Upcoming commits will include a script for interacting with the object / underlying hash table so that we can lock / unlock specific queues via command line.  Current options are to manipulate locks via redis-cli or via the python interpreter.
