### PR TITLE
Removed starttls() from notify.py so that notifications actually work

### DIFF
--- a/pds_pipelines/notify.py
+++ b/pds_pipelines/notify.py
@@ -10,8 +10,6 @@ def setup_smtp():
     server = smtplib.SMTP()
     server.connect()
     server.ehlo()
-    server.starttls()
-    server.ehlo
     return server
 
 


### PR DESCRIPTION
This PR helps tie off #118. The underlying notification code was put in place during an earlier PR, but it turns out that the server we run notifications from doesn't support TLS, so the script was erroring out. This PR simply removes `starttls()` from `notify.py` in order to get notifications working again.