### PR TITLE
Fixed QFile2QWork function

### DIFF
--- a/pds_pipelines/RedisQueue.py
+++ b/pds_pipelines/RedisQueue.py
@@ -106,6 +106,5 @@ class RedisQueue(object):
         str
             item
         """
-        item = self._db.lpop(popQ)
-        self._db.rpush(popQ, item)
+        item = self._db.rpoplpush(popQ, pushQ)
         return item


### PR DESCRIPTION
Fixed QFile2QWork to correctly use rpoplpush instead of two separate steps.

Potentially addresses #216 