### PR TITLE
Added no-run mode to Servicejobber.py

### DIFF
--- a/pds_pipelines/Servicejobber.py
+++ b/pds_pipelines/Servicejobber.py
@@ -573,6 +573,10 @@ class Args(object):
                             '-n',
                             dest='namespace',
                             help="Queue namespace")
+        parser.add_argument('--norun',
+                            help="Set up queues and write out SBATCH script, but do not submit it to SLURM",
+                            action="store_true")
+
         args = parser.parse_args()
         self.key = args.key
         self.namespace = args.namespace
@@ -1012,12 +1016,16 @@ def main():
     except IOError as e:
         logger.error('SBATCH File %s Not Found', SBfile)
 
-    try:
-        jobOBJ.Run()
-        logger.info('Job Submission to HPC: Success')
-        DBQO.setJobsStarted(key)
-    except IOError as e:
-        logger.error('Jobs NOT Submitted to HPC')
+
+    if args.norun:
+        logger.info('No-run mode, will not submit HPC job.')
+    else:
+        try:
+            jobOBJ.Run()
+            logger.info('Job Submission to HPC: Success')
+            DBQO.setJobsStarted(key)
+        except IOError as e:
+            logger.error('Jobs NOT Submitted to HPC')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #220 
Added a new command line option to `Servicejobber.py`, `--norun`, which causes the script to run as usual except

1. It will not submit the SBATCH script to SLURM
2. It will not set the JobStarted timestamp

