### PR TITLE
Servicejobber.py typo fix

### DIFF
--- a/pds_pipelines/Servicejobber.py
+++ b/pds_pipelines/Servicejobber.py
@@ -580,6 +580,7 @@ class Args(object):
         args = parser.parse_args()
         self.key = args.key
         self.namespace = args.namespace
+        self.norun = args.norun
 
 def main():
     args = Args()


### PR DESCRIPTION
I forgot to add `self.norun = args.norun` when I added the `--norun` option in #221 