### PR TITLE
Added missing spiceinit to POW recipe for mo_themis_ir_edr

### DIFF
--- a/recipe/new/mo_themis_ir_edr.json
+++ b/recipe/new/mo_themis_ir_edr.json
@@ -47,6 +47,11 @@
                 "from_": "value",
                 "to": "value"
             },
+            "spiceinit": {
+                "from_": "value",
+                "cknadir": "yes",
+                "cksmithed": "yes"
+            },
             "cam2map": {
                 "from": "value",
                 "to": "value",


### PR DESCRIPTION
It appears that the call to `spiceinit` was missing from the POW recipe for THEMIS IR processing, which caused POW processing to fail. I testing this fix on a couple THEMIS IR products and it appears to work just fine.