### PR TITLE
Added .decode functionality to RedisQueue, refactored calls to RQ.get*

### DIFF
--- a/pds_pipelines/DIprocess.py
+++ b/pds_pipelines/DIprocess.py
@@ -64,7 +64,7 @@ def main():
     logger.info("DI Queue: %s", RQ.id_name)
 
     while int(RQ.QueueSize()) > 0 and RQ_lock.available(RQ.id_name):
-        item = literal_eval(RQ.QueueGet().decode("utf-8"))
+        item = literal_eval(RQ.QueueGet())
         inputfile = item[0]
         archive = item[1]
         logger.debug("%s - %s", inputfile, archive) 

--- a/pds_pipelines/IngestProcess.py
+++ b/pds_pipelines/IngestProcess.py
@@ -79,7 +79,7 @@ def main():
 
     while int(RQ_main.QueueSize()) > 0 and RQ_lock.available(RQ_main.id_name):
 
-        item = literal_eval(RQ_main.QueueGet().decode("utf-8"))
+        item = literal_eval(RQ_main.QueueGet())
         inputfile = item[0]
         archive = item[1]
         RQ_work.QueueAdd(inputfile)

--- a/pds_pipelines/LinkArtifacts.py
+++ b/pds_pipelines/LinkArtifacts.py
@@ -45,7 +45,7 @@ def main():
 
     while int(RQ.QueueSize()) > 0:
         # Grab a tuple of values from the redis queue
-        item = literal_eval(RQ.QueueGet().decode('utf-8'))
+        item = literal_eval(RQ.QueueGet())
         # Split tuple into two values
         inputfile = item[0]
         archive = item[1]

--- a/pds_pipelines/MAPprocess.py
+++ b/pds_pipelines/MAPprocess.py
@@ -61,8 +61,8 @@ def main():
     if int(RQ_file.QueueSize()) == 0 and RQ_lock.available('MAP'):
         print("No Files Found in Redis Queue")
     else:
-        jobFile = RQ_file.Qfile2Qwork(
-            RQ_file.getQueueName(), RQ_work.getQueueName()).decode('utf-8')
+        jobFile = RQ_file.Qfile2Qwork(RQ_file.getQueueName(),
+                                      RQ_work.getQueueName())
 
         # Setup system logging
         basename = os.path.splitext(os.path.basename(jobFile))[0]

--- a/pds_pipelines/POWprocess.py
+++ b/pds_pipelines/POWprocess.py
@@ -63,8 +63,8 @@ def main():
         print("No Files Found in Redis Queue")
     else:
         print(RQ_file.getQueueName())
-        jobFile = RQ_file.Qfile2Qwork(
-            RQ_file.getQueueName(), RQ_work.getQueueName()).decode('utf-8')
+        jobFile = RQ_file.Qfile2Qwork(RQ_file.getQueueName(),
+                                      RQ_work.getQueueName())
 
         # Setup system logging
         basename = os.path.splitext(os.path.basename(jobFile))[0]

--- a/pds_pipelines/RedisQueue.py
+++ b/pds_pipelines/RedisQueue.py
@@ -5,6 +5,14 @@ from pds_pipelines.config import redis_info as ri
 from pds_pipelines.config import default_namespace
 
 
+def conditional_decode(item, charset='utf-8'):
+    try:
+        item = item.decode(charset)
+    except AttributeError:
+        # Intentionally left blank -- if the item can't be decoded, just return it.
+        pass
+    return item
+
 class RedisQueue(object):
     """
     Attributes
@@ -20,16 +28,13 @@ class RedisQueue(object):
         name : str
         namespace : str
         """
-
-        # self._db=redis.Redis(host=ri['host'], port=ri['port'], db=ri['db'])
         self._db=redis.StrictRedis(host=ri['host'], port=ri['port'], db=ri['db'])
-        # @TODO change back to non-local queue
-        #self._db = redis.StrictRedis(host='redis')
-        #self._db = redis.StrictRedis(host='localhost')
         self.id_name = '%s:%s' % (namespace, name)
+
 
     def RemoveAll(self):
         self._db.delete(self.id_name)
+
 
     def getQueueName(self):
         """
@@ -38,7 +43,8 @@ class RedisQueue(object):
         str
             id_name
         """
-        return self.id_name
+        return conditional_decode(self.id_name)
+
 
     def QueueSize(self):
         """
@@ -49,6 +55,7 @@ class RedisQueue(object):
         """
         return self._db.llen(self.id_name)
 
+
     def QueueAdd(self, element):
         """
         Parameters
@@ -57,6 +64,7 @@ class RedisQueue(object):
         """
         self._db.rpush(self.id_name, element)
 
+
     def QueueGet(self):
         """
         Returns
@@ -64,8 +72,8 @@ class RedisQueue(object):
         str
             item
         """
-        item = self._db.lpop(self.id_name)
-        return item
+        return conditional_decode(self._db.lpop(self.id_name))
+
 
     def ListGet(self):
         """
@@ -73,8 +81,9 @@ class RedisQueue(object):
         -------
         list
         """
-        list = self._db.lrange(self.id_name, 0, -1)
-        return list
+        items = self._db.lrange(self.id_name, 0, -1)
+        return list(map(conditional_decode, items))
+
 
     def RecipeGet(self):
         """
@@ -85,6 +94,7 @@ class RedisQueue(object):
         recipe = self._db.lrange(self.id_name, 0, -1)
         return recipe
 
+
     def QueueRemove(self, element):
         """
         Parameters
@@ -93,6 +103,7 @@ class RedisQueue(object):
         """
         value = int(0)
         self._db.lrem(self.id_name, value, element)
+
 
     def Qfile2Qwork(self, popQ, pushQ):
         """

--- a/pds_pipelines/UPC_process.py
+++ b/pds_pipelines/UPC_process.py
@@ -137,11 +137,10 @@ def main():
     # while there are items in the redis queue
     while int(RQ_main.QueueSize()) > 0 and RQ_lock.available(RQ_main.id_name):
         # get a file from the queue
-        item = literal_eval(RQ_main.QueueGet().decode("utf-8"))
+        item = literal_eval(RQ_main.QueueGet())
         inputfile = item[0]
         fid = item[1]
         archive = item[2]
-        #inputfile = (RQ_main.QueueGet()).decode('utf-8')
         if os.path.isfile(inputfile):
             pass
         else:

--- a/pds_pipelines/browse_process.py
+++ b/pds_pipelines/browse_process.py
@@ -158,7 +158,7 @@ def main():
     tid = get_tid('fullimageurl', upc_session)
 
     while int(RQ_main.QueueSize()) > 0 and RQ_lock.available(RQ_main.id_name):
-        item = literal_eval(RQ_main.QueueGet().decode("utf-8"))
+        item = literal_eval(RQ_main.QueueGet())
         inputfile = item[0]
         fid = item[1]
         archive = item[2]

--- a/pds_pipelines/thumbnail_process.py
+++ b/pds_pipelines/thumbnail_process.py
@@ -141,7 +141,7 @@ def main():
     tid = get_tid('thumbnailurl', upc_session)
 
     while int(RQ_main.QueueSize()) > 0 and RQ_lock.available(RQ_main.id_name):
-        item = literal_eval(RQ_main.QueueGet().decode("utf-8"))
+        item = literal_eval(RQ_main.QueueGet())
         inputfile = item[0]
         fid = item[1]
         archive = item[2]


### PR DESCRIPTION
Moved decode functionality to RedisQueue in order to perform conditional
decode operations based on the type of data being popped from the queue.

Byte typed items are decoded to utf-8 by default, all other types are popped
in their original data type.

Removed .decode calls from code in any areas that deal directly with information
from the RedisQueue class.

Did not remove .decode calls from areas that do not get information from the
RedisQueue class.  The following scripts still use inline .decode calls:

- thumbnail_process: decodes value not obtained from RedisQueue
- RedisLock: decodes value obtained from underlying _db object, which does not deal with RQ class
- lock_queue: Does not use RedisQueue as underlying data structure
- browse_process: decodes value not obtained from RedisQueue
- UPC_process: decodes multiple values not obtained from RedisQueue

Fixes #226 Fixes #205 