### PR TITLE
Revert "Removed args classes in favor of more traditional argparse us…

### DIFF
--- a/pds_pipelines/BatchDI.py
+++ b/pds_pipelines/BatchDI.py
@@ -11,21 +11,28 @@ from pds_pipelines.db import db_connect
 from pds_pipelines.config import pds_info, pds_db, pds_log
 
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="DI Process")
+class Args(object):
+    def __init__(self):
+        pass
 
-    parser.add_argument('--log', '-l', dest="log_level",
-                        choices=['DEBUG', 'INFO',
-                                'WARNING', 'ERROR', 'CRITICAL'],
-                        help="Set the log level.", default='INFO')
+    def parse_args(self):
+        parser = argparse.ArgumentParser(description="DI Process")
 
-    args = parser.parse_args()
-    return args
+        parser.add_argument('--log', '-l', dest="log_level",
+                            choices=['DEBUG', 'INFO',
+                                    'WARNING', 'ERROR', 'CRITICAL'],
+                            help="Set the log level.", default='INFO')
+
+        args = parser.parse_args()
+        self.log_level = args.log_level
 
 
-def main(log_level):
+def main():
+    args = Args()
+    args.parse_args()
+
     logger = logging.getLogger('DI_Queueing')
-    level = logging.getLevelName(log_level)
+    level = logging.getLevelName(args.log_level)
     logger.setLevel(level)
     logFileHandle = logging.FileHandler(pds_log + 'DI.log')
     formatter = logging.Formatter(
@@ -61,5 +68,4 @@ def main(log_level):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    main(**vars(args))
+    main()

--- a/pds_pipelines/DIprocess.py
+++ b/pds_pipelines/DIprocess.py
@@ -16,23 +16,30 @@ from pds_pipelines.config import pds_db, pds_log, pds_info, lock_obj
 from pds_pipelines.db import db_connect
 from pds_pipelines.models.pds_models import Files
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="DI Process")
+class Args(object):
+    def __init__(self):
+        pass
 
-    parser.add_argument('--log', '-l', dest="log_level",
-                        choices=['DEBUG', 'INFO',
-                                'WARNING', 'ERROR', 'CRITICAL'],
-                        help="Set the log level.", default='INFO')
+    def parse_args(self):
+        parser = argparse.ArgumentParser(description="DI Process")
 
-    args = parser.parse_args()
-    return args
+        parser.add_argument('--log', '-l', dest="log_level",
+                            choices=['DEBUG', 'INFO',
+                                    'WARNING', 'ERROR', 'CRITICAL'],
+                            help="Set the log level.", default='INFO')
 
-def main(log_level):
+        args = parser.parse_args()
+        self.log_level = args.log_level
+
+
+def main():
     PDSinfoDICT = json.load(open(pds_info, 'r'))
+    args = Args()
+    args.parse_args()
 
     # Set up logging
     logger = logging.getLogger('DI_Process')
-    level = logging.getLevelName(log_level)
+    level = logging.getLevelName(args.log_level)
     logger.setLevel(level)
     logFileHandle = logging.FileHandler(pds_log + 'DI.log')
     formatter = logging.Formatter(
@@ -104,5 +111,4 @@ def main(log_level):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main())

--- a/pds_pipelines/DIqueueing.py
+++ b/pds_pipelines/DIqueueing.py
@@ -12,45 +12,88 @@ from pds_pipelines.db import db_connect
 from pds_pipelines.models.pds_models import Files
 from pds_pipelines.config import pds_info, pds_db, pds_log
 from sqlalchemy import Date, cast
+from sqlalchemy.orm.util import *
 from sqlalchemy import or_
 
 
-def parse_args():
-    parser = argparse.ArgumentParser(description='PDS DI Data Integrity')
+class Args(object):
+    """
+    Objects that have the attributes described below
 
-    parser.add_argument('--archive', '-a', dest="archive", required=True,
-                        help="Enter archive - archive to ingest")
+    Attributes
+    ----------
+    archive : str
+    volume : str
+    jobarray : str
+    """
+    def __init__(self):
+        pass
 
-    parser.add_argument('--volume', '-v', dest="volume",
-                        help="Enter volume to Ingest")
+    def parse_args(self):
+        """
+        Defines how to parse command-line arguments
 
-    parser.add_argument('--jobarray', '-j', dest="jobarray",
-                        help="Enter string to set job array size")
+        Parameters
+        ----------
+        name : str
+              name of argument
 
-    parser.add_argument('--log', '-l', dest="log_level",
-                        choices=['DEBUG', 'INFO',
-                                'WARNING', 'ERROR', 'CRITICAL'],
-                        help="Set the log level.", default='INFO')
+        dest : str
+            Name of attribute to be added to parser
 
-    args = parser.parse_args()
-    return args
+        required : str
+            Makes optional arguments required
 
+        help : _helper
+            Contains brief description of argument
 
-def main(archive, volume, jobarray, log_level):
+        Returns
+        -------
+        Namespace
+            args
+        """
+
+        parser = argparse.ArgumentParser(description='PDS DI Data Integrity')
+
+        parser.add_argument('--archive', '-a', dest="archive", required=True,
+                            help="Enter archive - archive to ingest")
+
+        parser.add_argument('--volume', '-v', dest="volume",
+                            help="Enter volume to Ingest")
+
+        parser.add_argument('--jobarray', '-j', dest="jobarray",
+                            help="Enter string to set job array size")
+
+        parser.add_argument('--log', '-l', dest="log_level",
+                            choices=['DEBUG', 'INFO',
+                                    'WARNING', 'ERROR', 'CRITICAL'],
+                            help="Set the log level.", default='INFO')
+
+        args = parser.parse_args()
+
+        self.archive = args.archive
+        self.volume = args.volume
+        self.jobarray = args.jobarray
+        self.log_level = args.log_level
+
+def main():
+    args = Args()
+    args.parse_args()
+
     RQ = RedisQueue('DI_ReadyQueue')
 
     PDSinfoDICT = json.load(open(pds_info, 'r'))
     try:
-        archiveID = PDSinfoDICT[archive]['archiveid']
+        archiveID = PDSinfoDICT[args.archive]['archiveid']
     except KeyError:
-        print("\nArchive '{}' not found in {}\n".format(archive, pds_info))
+        print("\nArchive '{}' not found in {}\n".format(args.archive, pds_info))
         print("The following archives are available:")
         for k in PDSinfoDICT.keys():
             print("\t{}".format(k))
         exit()
 
-    logger = logging.getLogger('DI_Queueing.' + archive)
-    level = logging.getLevelName(log_level)
+    logger = logging.getLogger('DI_Queueing.' + args.archive)
+    level = logging.getLevelName(args.log_level)
     logger.setLevel(level)
     logFileHandle = logging.FileHandler(pds_log + 'DI.log')
     formatter = logging.Formatter(
@@ -60,9 +103,9 @@ def main(archive, volume, jobarray, log_level):
 
     logger.info("DI Queue: %s", RQ.id_name)
     
-    logger.info('Starting %s DI Queueing', archive)
-    if volume:
-        logger.info('Queueing %s Volume', volume)
+    logger.info('Starting %s DI Queueing', args.archive)
+    if args.volume:
+        logger.info('Queueing %s Volume', args.volume)
 
     try:
         session, _ = db_connect(pds_db)
@@ -75,8 +118,8 @@ def main(archive, volume, jobarray, log_level):
           datetime.timedelta(days=30)).strftime("%Y-%m-%d %H:%M:%S")
     testing_date = datetime.datetime.strptime(str(td), "%Y-%m-%d %H:%M:%S")
 
-    if volume:
-        volstr = '%' + volume + '%'
+    if args.volume:
+        volstr = '%' + args.volume + '%'
         testQ = session.query(Files).filter(
             Files.archiveid == archiveID, Files.filename.like(volstr)).filter(
                 or_(cast(Files.di_date, Date) < testing_date,
@@ -89,7 +132,7 @@ def main(archive, volume, jobarray, log_level):
     addcount = 0
     for element in testQ:
         try:
-            RQ.QueueAdd((element.filename, archive))
+            RQ.QueueAdd((element.filename, args.archive))
             addcount = addcount + 1
         except:
             logger.warn('File %s Not Added to DI_ReadyQueue',
@@ -100,5 +143,4 @@ def main(archive, volume, jobarray, log_level):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main())

--- a/pds_pipelines/FinalJobber.py
+++ b/pds_pipelines/FinalJobber.py
@@ -9,30 +9,39 @@ from pds_pipelines.HPCjob import HPCjob
 from pds_pipelines.config import pds_log, slurm_log, cmd_dir, scratch, default_namespace
 
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="DI Process")
+class Args(object):
+    def __init__(self):
+        pass
 
-    parser.add_argument('--log', '-l', dest="log_level",
-                        choices=['DEBUG', 'INFO',
-                                'WARNING', 'ERROR', 'CRITICAL'],
-                        help="Set the log level.", default='INFO')
+    def parse_args(self):
+        parser = argparse.ArgumentParser(description="DI Process")
 
-    parser.add_argument('--namespace',
-                        '-n',
-                        dest='namespace',
-                        help="Queue namespace")
+        parser.add_argument('--log', '-l', dest="log_level",
+                            choices=['DEBUG', 'INFO',
+                                    'WARNING', 'ERROR', 'CRITICAL'],
+                            help="Set the log level.", default='INFO')
+
+        parser.add_argument('--namespace',
+                            '-n',
+                            dest='namespace',
+                            help="Queue namespace")
 
 
-    args = parser.parse_args()
-    return args
+        args = parser.parse_args()
+        self.log_level = args.log_level
+        self.namespace = args.namespace
 
 
-def main(log_level, namespace=None):
+def main():
+    args = Args()
+    args.parse_args()
+    namespace = args.namespace
+
     if namespace is None:
         namespace = default_namespace
 
     logger = logging.getLogger('FinalJobber')
-    level = logging.getLevelName(log_level)
+    level = logging.getLevelName(args.log_level)
     logger.setLevel(level)
     logFileHandle = logging.FileHandler(pds_log+'Service.log')
     formatter = logging.Formatter(
@@ -84,5 +93,4 @@ def main(log_level, namespace=None):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main())

--- a/pds_pipelines/IngestProcess.py
+++ b/pds_pipelines/IngestProcess.py
@@ -16,26 +16,34 @@ from pds_pipelines.config import pds_info, pds_log, pds_db, archive_base, web_ba
 from pds_pipelines.models.pds_models import Files
 
 
-def parse_args():
+class Args(object):
+    def __init__(self):
+        pass
 
-    parser = argparse.ArgumentParser(description='PDS DI Database Ingest')
+    def parse_args(self):
 
-    parser.add_argument('--override', dest='override', action='store_true')
-    parser.set_defaults(override=False)
+        parser = argparse.ArgumentParser(description='PDS DI Database Ingest')
 
-    parser.add_argument('--log', '-l', dest="log_level",
-                        choices=['DEBUG', 'INFO',
-                                'WARNING', 'ERROR', 'CRITICAL'],
-                        help="Set the log level.", default='INFO')
+        parser.add_argument('--override', dest='override', action='store_true')
+        parser.set_defaults(override=False)
 
-    args = parser.parse_args()
-    return args
+        parser.add_argument('--log', '-l', dest="log_level",
+                            choices=['DEBUG', 'INFO',
+                                    'WARNING', 'ERROR', 'CRITICAL'],
+                            help="Set the log level.", default='INFO')
+
+        args = parser.parse_args()
+        self.log_level = args.log_level
+        self.override = args.override
 
 
-def main(log_level, override):
+def main():
 
+    args = Args()
+    args.parse_args()
+    override = args.override
     logger = logging.getLogger('Ingest_Process')
-    level = logging.getLevelName(log_level)
+    level = logging.getLevelName(args.log_level)
     logger.setLevel(level)
     logFileHandle = logging.FileHandler(pds_log + 'Ingest.log')
     print("Log File: {}Ingest.log".format(pds_log))
@@ -172,5 +180,4 @@ def main(log_level, override):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main())

--- a/pds_pipelines/Ingestqueueing.py
+++ b/pds_pipelines/Ingestqueueing.py
@@ -9,38 +9,56 @@ import argparse
 from pds_pipelines.RedisQueue import RedisQueue
 from pds_pipelines.config import pds_info, pds_log
 
+class Args(object):
+    """
+    Attributes
+    ----------
+    archive : str
+    volume : str
+    search : str
+    """
+    def __init__(self):
+        pass
 
-def parse_args():
-    parser = argparse.ArgumentParser(description='PDS DI Database Ingest')
+    def parse_args(self):
 
-    parser.add_argument('--archive', '-a', dest="archive", required=True,
-                        help="Enter archive - archive to ingest")
+        parser = argparse.ArgumentParser(description='PDS DI Database Ingest')
 
-    parser.add_argument('--volume', '-v', dest="volume",
-                        help="Enter volume to Ingest")
+        parser.add_argument('--archive', '-a', dest="archive", required=True,
+                            help="Enter archive - archive to ingest")
 
-    parser.add_argument('--log', '-l', dest="log_level",
-                        choices=['DEBUG', 'INFO', 'WARNING',
-                                'ERROR', 'CRITICAL'],
-                        help="Set the log level.", default='INFO')
+        parser.add_argument('--volume', '-v', dest="volume",
+                            help="Enter volume to Ingest")
 
-    parser.add_argument('--search', '-s', dest="search",
-                        help="Enter string to search for")
+        parser.add_argument('--log', '-l', dest="log_level",
+                            choices=['DEBUG', 'INFO', 'WARNING',
+                                    'ERROR', 'CRITICAL'],
+                            help="Set the log level.", default='INFO')
 
-    parser.add_argument('--link-only', dest='ingest', action='store_false')
-    parser.set_defaults(ingest=True)
+        parser.add_argument('--search', '-s', dest="search",
+                            help="Enter string to search for")
 
-    args = parser.parse_args()
-    return args
+        parser.add_argument('--link-only', dest='ingest', action='store_false')
+        parser.set_defaults(ingest=True)
+        args = parser.parse_args()
 
+        self.archive = args.archive
+        self.volume = args.volume
+        self.log_level = args.log_level
+        self.search = args.search
+        self.ingest = args.ingest
 
-def main(archive, volume, log_level, search, ingest):
+def main():
+
+    args = Args()
+    args.parse_args()
+
     RQ_ingest = RedisQueue('Ingest_ReadyQueue')
     RQ_linking = RedisQueue('LinkQueue')
 
     # Set up logging
-    logger = logging.getLogger(archive + '_INGEST')
-    level = logging.getLevelName(log_level)
+    logger = logging.getLogger(args.archive + '_INGEST')
+    level = logging.getLevelName(args.log_level)
     logger.setLevel(level)
     logFileHandle = logging.FileHandler(pds_log + 'Ingest.log')
     formatter = logging.Formatter(
@@ -52,17 +70,17 @@ def main(archive, volume, log_level, search, ingest):
 
     PDSinfoDICT = json.load(open(pds_info, 'r'))
     try:
-        archivepath = PDSinfoDICT[archive]['path'][:-1]
+        archivepath = PDSinfoDICT[args.archive]['path'][:-1]
     except KeyError:
-        print("\nArchive '{}' not found in {}\n".format(archive, pds_info))
+        print("\nArchive '{}' not found in {}\n".format(args.archive, pds_info))
         print("The following archives are available:")
         for k in PDSinfoDICT.keys():
             print("\t{}".format(k))
-        logging.error("Unable to locate %s", archive)
+        logging.error("Unable to locate %s", args.archive)
         exit()
 
-    if volume:
-        archivepath = archivepath + '/' + volume
+    if args.volume:
+        archivepath = archivepath + '/' + args.volume
 
     logger.info('Starting Ingest for: %s', archivepath)
     logger.info('Ingest Queue: %s', str(RQ_ingest.id_name))
@@ -74,13 +92,13 @@ def main(archive, volume, log_level, search, ingest):
     for dirpath, _, files in os.walk(archivepath):
         for filename in files:
             fname = os.path.join(dirpath, filename)
-            if search:
-                if search in fname:
+            if args.search:
+                if args.search in fname:
                     try:
                         if os.path.basename(fname) == "voldesc.cat":
                             voldescs.append(fname)
-                        if ingest:
-                            RQ_ingest.QueueAdd((fname, archive))
+                        if args.ingest:
+                            RQ_ingest.QueueAdd((fname, args.archive))
                     except Exception as e:
                         logger.warn('File %s NOT added to Ingest Queue: %s', fname, str(e))
                 else:
@@ -89,17 +107,16 @@ def main(archive, volume, log_level, search, ingest):
                 try:
                     if os.path.basename(fname) == "voldesc.cat":
                         voldescs.append(fname)
-                    if ingest:
-                        RQ_ingest.QueueAdd((fname, archive))
+                    if args.ingest:
+                        RQ_ingest.QueueAdd((fname, args.archive))
                 except Exception as e:
                     logger.warn('File %s NOT added to Ingest Queue: %s', fname, str(e))
 
     n_added = RQ_ingest.QueueSize() - queue_size
     for fpath in voldescs:
-        RQ_linking.QueueAdd((fpath, archive))
+        RQ_linking.QueueAdd((fpath, args.archive))
     logger.info('Files added to Ingest Queue: %s', n_added)
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main())

--- a/pds_pipelines/LinkArtifacts.py
+++ b/pds_pipelines/LinkArtifacts.py
@@ -5,28 +5,36 @@ import pvl
 import json
 import logging
 import argparse
+from xmljson import badgerfish as bf
 from pds_pipelines.config import recipe_base, link_dest
 from pds_pipelines.RedisQueue import RedisQueue
 from ast import literal_eval
 from pds_pipelines.config import pds_log
 
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="DI Process")
+class Args(object):
+    def __init__(self):
+        pass
 
-    parser.add_argument('--log', '-l', dest="log_level",
-                        choices=['DEBUG', 'INFO',
-                                'WARNING', 'ERROR', 'CRITICAL'],
-                        help="Set the log level.", default='INFO')
+    def parse_args(self):
+        parser = argparse.ArgumentParser(description="DI Process")
 
-    args = parser.parse_args()
-    return args
+        parser.add_argument('--log', '-l', dest="log_level",
+                            choices=['DEBUG', 'INFO',
+                                    'WARNING', 'ERROR', 'CRITICAL'],
+                            help="Set the log level.", default='INFO')
 
-def main(log_level):
+        args = parser.parse_args()
+        self.log_level = args.log_level
+
+
+def main():
     RQ = RedisQueue('LinkQueue')
+    args = Args()
+    args.parse_args()
 
     logger = logging.getLogger('LINK_Process')
-    level = logging.getLevelName(log_level)
+    level = logging.getLevelName(args.log_level)
     logger.setLevel(level)
     logFileHandle = logging.FileHandler(pds_log + 'Link.log')
     formatter = logging.Formatter(
@@ -104,5 +112,4 @@ def load_pvl(pvl_file_path):
 
 
 if __name__ == '__main__':
-    args = parse_args()
-    main(**vars(args))
+    main()

--- a/pds_pipelines/MAPprocess.py
+++ b/pds_pipelines/MAPprocess.py
@@ -19,25 +19,35 @@ from pds_pipelines.SubLoggy import SubLoggy
 from pds_pipelines.Process import Process
 
 
-def parse_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--key',
-                        '-k',
-                        dest='key',
-                        help="Target key -- if blank, process first element in queue")
-    parser.add_argument('--namespace',
-                        '-n',
-                        dest='namespace',
-                        help="Queue namespace")
-    args = parser.parse_args()
-    return args
+class Args(object):
+    def __init__(self):
+        pass
+
+    def parse_args(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--key',
+                            '-k',
+                            dest='key',
+                            help="Target key -- if blank, process first element in queue")
+        parser.add_argument('--namespace',
+                            '-n',
+                            dest='namespace',
+                            help="Queue namespace")
+        args = parser.parse_args()
+        self.key = args.key
+        self.namespace = args.namespace
 
 
-def main(key, namespace=None):
+def main():
+    args = Args()
+    args.parse_args()
+    key = args.key
+    namespace = args.namespace
+
     if namespace is None:
         namespace = default_namespace
 
-    workarea = scratch + key + '/'
+    workarea = scratch + args.key + '/'
     RQ_file = RedisQueue(key + '_FileQueue', namespace)
     RQ_work = RedisQueue(key + '_WorkQueue', namespace)
     RQ_zip = RedisQueue(key + '_ZIP', namespace)
@@ -242,5 +252,4 @@ def main(key, namespace=None):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main())

--- a/pds_pipelines/POWprocess.py
+++ b/pds_pipelines/POWprocess.py
@@ -20,22 +20,31 @@ from pds_pipelines.Loggy import Loggy
 from pds_pipelines.SubLoggy import SubLoggy
 
 
-def parse_args():
-    parser = argparse.ArgumentParser(description='Processing for Projection on the Web')
-    parser.add_argument('--key',
-                        '-k',
-                        dest='key',
-                        help='Target key')
-    parser.add_argument('--namespace',
-                        '-n',
-                        dest='namespace',
-                        help='Target key')
+class Args(object):
+    def __init__(self):
+        pass
 
-    args = parser.parse_args()
-    return args
+    def parse_args(self):
+        parser = argparse.ArgumentParser(description='Processing for Projection on the Web')
+        parser.add_argument('--key',
+                            '-k',
+                            dest='key',
+                            help='Target key')
+        parser.add_argument('--namespace',
+                            '-n',
+                            dest='namespace',
+                            help='Target key')
+        args = parser.parse_args()
+        self.key = args.key
+        self.namespace = args.namespace
 
 
-def main(key, namespace=None):
+def main():
+    args = Args()
+    args.parse_args()
+    key = args.key
+    namespace = args.namespace
+
     if namespace is None:
         namespace = default_namespace
 
@@ -339,5 +348,4 @@ def main(key, namespace=None):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main())

--- a/pds_pipelines/ServiceFinal.py
+++ b/pds_pipelines/ServiceFinal.py
@@ -30,33 +30,44 @@ def renderError(errorhash):
         print(key)
 
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="Service Final")
+class Args(object):
+    def __init__(self):
+        pass
 
-    parser.add_argument('--log', '-l', dest="log_level",
-                        choices=['DEBUG', 'INFO',
-                                'WARNING', 'ERROR', 'CRITICAL'],
-                        help="Set the log level.", default='INFO')
+    def parse_args(self):
+        parser = argparse.ArgumentParser(description="DI Process")
 
-    parser.add_argument('--namespace',
-                        '-n',
-                        dest='namespace',
-                        help="Queue namespace")
+        parser.add_argument('--log', '-l', dest="log_level",
+                            choices=['DEBUG', 'INFO',
+                                    'WARNING', 'ERROR', 'CRITICAL'],
+                            help="Set the log level.", default='INFO')
 
-    parser.add_argument('--key',
-                        '-k',
-                        dest='key',
-                        help='Job key')
+        parser.add_argument('--namespace',
+                            '-n',
+                            dest='namespace',
+                            help="Queue namespace")
 
-    args = parser.parse_args()
-    return args
+        parser.add_argument('--key',
+                            '-k',
+                            dest='key',
+                            help='Job key')
+
+        args = parser.parse_args()
+        self.log_level = args.log_level
+        self.namespace = args.namespace
+        self.key = args.key
 
 
-def main(log_level, namespace, key):
+def main():
+
+    args = Args()
+    args.parse_args()
+    namespace = args.namespace
+    key = args.key
 
 #***************** Setup Logging **************
     logger = logging.getLogger('ServiceFinal_' + key)
-    level = logging.getLevelName(log_level)
+    level = logging.getLevelName(args.log_level)
     logger.setLevel(level)
     logFileHandle = logging.FileHandler(pds_log+'Service.log')
 
@@ -287,5 +298,4 @@ def main(log_level, namespace, key):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main())

--- a/pds_pipelines/Servicejobber.py
+++ b/pds_pipelines/Servicejobber.py
@@ -558,25 +558,36 @@ class jobXML(object):
         return listArray
 
 
-def parse_args():
-    parser = argparse.ArgumentParser(description='Service job manager')
-    parser.add_argument('--key',
-                        '-k',
-                        dest='key',
-                        help="Target key -- if blank, process first element in queue")
-    parser.add_argument('--namespace',
-                        '-n',
-                        dest='namespace',
-                        help="Queue namespace")
-    parser.add_argument('--norun',
-                        help="Set up queues and write out SBATCH script, but do not submit it to SLURM",
-                        action="store_true")
+class Args(object):
 
-    args = parser.parse_args()
-    return args
+    def __init__(self):
+        pass
 
+    def parse_args(self):
+        parser = argparse.ArgumentParser(description='Service job manager')
+        parser.add_argument('--key',
+                            '-k',
+                            dest='key',
+                            help="Target key -- if blank, process first element in queue")
+        parser.add_argument('--namespace',
+                            '-n',
+                            dest='namespace',
+                            help="Queue namespace")
+        parser.add_argument('--norun',
+                            help="Set up queues and write out SBATCH script, but do not submit it to SLURM",
+                            action="store_true")
 
-def main(key, norun, namespace=None):
+        args = parser.parse_args()
+        self.key = args.key
+        self.namespace = args.namespace
+        self.norun = args.norun
+
+def main():
+    args = Args()
+    args.parse_args()
+    key = args.key
+    namespace = args.namespace
+
     if namespace is None:
         namespace = default_namespace
 
@@ -1011,7 +1022,7 @@ def main(key, norun, namespace=None):
         logger.error('SBATCH File %s Not Found', SBfile)
 
 
-    if norun:
+    if args.norun:
         logger.info('No-run mode, will not submit HPC job.')
     else:
         try:
@@ -1023,5 +1034,4 @@ def main(key, norun, namespace=None):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main())

--- a/pds_pipelines/batchUPC.py
+++ b/pds_pipelines/batchUPC.py
@@ -9,24 +9,30 @@ from pds_pipelines.models.pds_models import Files, Archives
 from pds_pipelines.config import pds_info, pds_db, pds_log
 
 
+class Args(object):
+    def __init__(self):
+        pass
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="DI Process")
+    def parse_args(self):
+        parser = argparse.ArgumentParser(description="DI Process")
 
-    parser.add_argument('--log', '-l', dest="log_level",
-                        choices=['DEBUG', 'INFO',
-                                'WARNING', 'ERROR', 'CRITICAL'],
-                        help="Set the log level.", default='INFO')
+        parser.add_argument('--log', '-l', dest="log_level",
+                            choices=['DEBUG', 'INFO',
+                                    'WARNING', 'ERROR', 'CRITICAL'],
+                            help="Set the log level.", default='INFO')
 
-    args = parser.parse_args()
-    return args
+        args = parser.parse_args()
+        self.log_level = args.log_level
 
 
-def main(log_level):
+def main():
+    args = Args()
+    args.parse_args()
+
     PDS_info = json.load(open(pds_info, 'r'))
     reddis_queue = RedisQueue('UPC_ReadyQueue')
     logger = logging.getLogger('UPC_Queueing')
-    level = logging.getLevelName(log_level)
+    level = logging.getLevelName(args.log_level)
     logger.setLevel(level)
     logFileHandle = logging.FileHandler(pds_log + 'Process.log')
     formatter = logging.Formatter(
@@ -76,5 +82,4 @@ def main(log_level):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    main(**vars(args))
+    main()

--- a/pds_pipelines/browse_process.py
+++ b/pds_pipelines/browse_process.py
@@ -113,21 +113,33 @@ def AddProcessDB(session, fid, outvalue):
         return 'ERROR'
 
 
-def parse_args(self):
-    parser = argparse.ArgumentParser(description="DI Process")
+class Args(object):
+    def __init__(self):
+        pass
 
-    parser.add_argument('--log', '-l', dest="log_level",
-                        choices=['DEBUG', 'INFO',
-                                'WARNING', 'ERROR', 'CRITICAL'],
-                        help="Set the log level.", default='INFO')
+    def parse_args(self):
+        parser = argparse.ArgumentParser(description="DI Process")
 
-    args = parser.parse_args()
-    return args
+        parser.add_argument('--log', '-l', dest="log_level",
+                            choices=['DEBUG', 'INFO',
+                                    'WARNING', 'ERROR', 'CRITICAL'],
+                            help="Set the log level.", default='INFO')
+
+        args = parser.parse_args()
+        self.log_level = args.log_level
 
 
-def main(log_level):
+
+def main():
+
+#    pdb.set_trace()
+
+    args = Args()
+    args.parse_args()
+
+
     logger = logging.getLogger('Browse_Process')
-    level = logging.getLevelName(log_level)
+    level = logging.getLevelName(args.log_level)
     logger.setLevel(level)
     logFileHandle = logging.FileHandler(pds_log + 'Process.log')
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s, %(message)s')
@@ -251,5 +263,4 @@ def main(log_level):
     pds_engine.dispose()
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main())

--- a/pds_pipelines/db_sync.py
+++ b/pds_pipelines/db_sync.py
@@ -22,44 +22,64 @@ class Autodict(dict):
         return value
 
 
-def parse_args():
-    parser = argparse.ArgumentParser(description='Database synchronization tool')
-
-    parser.add_argument('-p', dest="date",
-                        help="Sync data processed after the specified date")
-
-    parser.add_argument('-i', dest="instrument",
-                        help="Sync data for the specified instrument")
-
-    parser.add_argument('-s', dest="spacecraft",
-                        help="Sync data for the specified spacecraft")
-
-    parser.add_argument('-d', dest="database",
-                        help="Sync only to the specified database on the destination server")
-
-    parser.add_argument('-t', dest="target",
-                        help="Sync for the target, ignore UPC records on other targets")
-
-    parser.add_argument('-v', dest="loglevel",
-                        help="Enable verbose output", action="store_const",
-                        const=logging.INFO, default=logging.WARNING)
-
-    parser.add_argument('-S', dest="statistics",
-                        help="Only display statistics, do not sync data",
-                        action="store_true")
-
-    args = parser.parse_args()
-    return args
+class Args(object):
+    def __init__(self):
+        self.date = None
+        self.instrument = None
+        self.spacecraft = None
+        self.database = None
+        self.target = None
+        self.loglevel = None
+        self.statistics = None
 
 
-def main(date, instrument, spacecraft, database, target, loglevel, statistics):
-    logging.basicConfig(level=loglevel)
+    def parse_args(self):
+        parser = argparse.ArgumentParser(description='Database synchronization tool')
+
+        parser.add_argument('-p', dest="date",
+                            help="Sync data processed after the specified date")
+
+        parser.add_argument('-i', dest="instrument",
+                            help="Sync data for the specified instrument")
+
+        parser.add_argument('-s', dest="spacecraft",
+                            help="Sync data for the specified spacecraft")
+
+        parser.add_argument('-d', dest="database",
+                            help="Sync only to the specified database on the destination server")
+
+        parser.add_argument('-t', dest="target",
+                            help="Sync for the target, ignore UPC records on other targets")
+
+        parser.add_argument('-v', dest="loglevel",
+                            help="Enable verbose output", action="store_const",
+                            const=logging.INFO, default=logging.WARNING)
+
+        parser.add_argument('-S', dest="statistics",
+                            help="Only display statistics, do not sync data",
+                            action="store_true")
+
+        args = parser.parse_args()
+
+        self.date = args.date
+        self.instrument = args.instrument
+        self.spacecraft = args.spacecraft
+        self.database = args.database
+        self.target = args.target
+        self.loglevel = args.loglevel
+        self.statistics = args.statistics
+
+
+def main():
+    args = Args()
+    args.parse_args()
+    logging.basicConfig(level=args.loglevel)
     source_session, _ = db_connect(upc_db)
 
-    upc_ids = get_upc_ids(source_session, date, instrument,
-                          spacecraft, target)
+    upc_ids = get_upc_ids(source_session, args.date, args.instrument,
+                          args.spacecraft, args.target)
 
-    if statistics:
+    if args.statistics:
         get_stats(source_session, upc_ids)
         return
 
@@ -72,14 +92,14 @@ def main(date, instrument, spacecraft, database, target, loglevel, statistics):
         session, _ = db_connect(target)
         target_sessions[target] = session
 
-    instrument = get_instrument(source_session, instrument,
-                                spacecraft)
+    instrument = get_instrument(source_session, args.instrument,
+                                args.spacecraft)
 
     for target_session in target_sessions.values():
         sync_instrument(target_session, instrument)
 
-    instrument_keywords = get_keywords(source_session, instrument,
-                                       spacecraft)
+    instrument_keywords = get_keywords(source_session, args.instrument,
+                                       args.spacecraft)
     common_keywords = get_keywords(source_session, 'COMMON')
 
     # Sync keywords, instruments with all databases
@@ -383,6 +403,5 @@ def sync_upc_id(source_session, dest_sessions, upc_id, meta_types):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    main(**vars(args))
+    main()
 


### PR DESCRIPTION
Reverts USGS-Astrogeology/PDS-Pipelines#247

The original PR should not have been merged. 

The original PR properly removed the Args classes, but the `parse_args()` function needs to be called from `main()` in order to actually work. This is usually accomplished with a line like `args = parse_args()`.
Then the variables corresponding to the arguments become defined and available as something like `args.foo`.