### PR TITLE
Added error message for incorrect volume specification

### DIFF
--- a/pds_pipelines/DIqueueing.py
+++ b/pds_pipelines/DIqueueing.py
@@ -102,7 +102,7 @@ def main():
     logger.addHandler(logFileHandle)
 
     logger.info("DI Queue: %s", RQ.id_name)
-    
+
     logger.info('Starting %s DI Queueing', args.archive)
     if args.volume:
         logger.info('Queueing %s Volume', args.volume)
@@ -113,6 +113,16 @@ def main():
     except:
         logger.error('DataBase Connection: Error')
         return 1
+
+
+    if args.volume:
+        volstr = '%' + args.volume + '%'
+        vol_exists = session.query(Files).filter(
+            Files.archiveid == archiveID, Files.filename.like(volstr)).first()
+        if not vol_exists:
+            print(f"No files exist in the database for volume \"{args.volume}\"."
+            "  Either the volume does not exist or it has not been properly ingested.\n")
+            exit()
 
     td = (datetime.datetime.now(pytz.utc) -
           datetime.timedelta(days=30)).strftime("%Y-%m-%d %H:%M:%S")

--- a/pds_pipelines/FindDI_Ready.py
+++ b/pds_pipelines/FindDI_Ready.py
@@ -132,7 +132,7 @@ def main():
     # Add handler to print to stdout
     logStreamHandle = logging.StreamHandler()
     logStreamHandle.setLevel(level)
-    
+
     logger.addHandler(logFileHandle)
     logger.addHandler(logStreamHandle)
 
@@ -144,6 +144,14 @@ def main():
     except Exception as e:
         logger.error("%s", e)
     else:
+        if args.volume:
+            volstr = '%' + args.volume + '%'
+            vol_exists = session.query(Files).filter(
+                Files.archiveid == archiveID, Files.filename.like(volstr)).first()
+            if not vol_exists:
+                print(f"No files exist in the database for volume \"{args.volume}\"."
+                "  Either the volume does not exist or it has not been properly ingested.\n")
+                exit()
         # if db connection fails, there's no sense in doing this part
         td = (datetime.datetime.now(pytz.utc)
               - datetime.timedelta(days=30)).strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
Fixes #265  and fixes #266 

Checks for the existence of any file matching the volume descriptor.  If no files were found, the scripts print an error message and exit.

At the moment, it is not feasible to provide any specific guidance regarding which volumes are available.  That is, we can tell users that their volume doesn't exist, but we cannot recommend volumes that do exist.