### PR TITLE
Getkey pysis 284

### DIFF
--- a/pds_pipelines/UPC_process.py
+++ b/pds_pipelines/UPC_process.py
@@ -327,7 +327,6 @@ def main(persist, log_level):
                 Instruments.instrument == pds_label['INSTRUMENT_ID'],
                 Instruments.spacecraft == pds_label['SPACECRAFT_NAME']).first()
 
-        print(f'instrument {str(instrument_Qobj)}')
         # keyword definitions
         keywordsOBJ = None
         if status == 'success':
@@ -348,10 +347,9 @@ def main(persist, log_level):
                     f.write(filedata)
 
                 keywordsOBJ = UPCkeywords(caminfoOUT)
-                PDSid = getPDSid(caminfoOUT)
 
             input_datafile = DataFiles(isisid=keywordsOBJ.getKeyword('IsisId'),
-                                                  productid=PDSid,
+                                                  productid=getPDSid(caminfoOUT),
                                                   source=img_file,
                                                   detached_label=d_label,
                                                   instrumentid=instrument_Qobj.instrumentid,


### PR DESCRIPTION
Fixes #284 

During testing, discovered #323, so replaced `INSTRUMENT_ID` with `INSTRUMENT_NAME` on https://github.com/USGS-Astrogeology/PDS-Pipelines/issues/323#L290 to verify that PDS Product ID was being interpreted correctly. After testing, I reverted back to `INSTRUMENT_ID`.