### PR TITLE
Changed main to take in argparse instead of each individual argument

### DIFF
--- a/pds_pipelines/BatchDI.py
+++ b/pds_pipelines/BatchDI.py
@@ -23,7 +23,9 @@ def parse_args():
     return args
 
 
-def main(log_level):
+def main(user_args):
+    log_level = user_args.log_level
+    
     logger = logging.getLogger('DI_Queueing')
     level = logging.getLevelName(log_level)
     logger.setLevel(level)
@@ -61,5 +63,4 @@ def main(log_level):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    main(**vars(args))
+    main(parse_args())

--- a/pds_pipelines/DIprocess.py
+++ b/pds_pipelines/DIprocess.py
@@ -27,7 +27,9 @@ def parse_args():
     args = parser.parse_args()
     return args
 
-def main(log_level):
+def main(user_args):
+    log_level = user_args.log_level
+
     PDSinfoDICT = json.load(open(pds_info, 'r'))
 
     # Set up logging
@@ -104,5 +106,4 @@ def main(log_level):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main(parse_args()))

--- a/pds_pipelines/DIqueueing.py
+++ b/pds_pipelines/DIqueueing.py
@@ -36,7 +36,12 @@ def parse_args():
     return args
 
 
-def main(archive, volume, jobarray, log_level):
+def main(user_args):
+    archive = user_args.archive
+    volume = user_args.volume
+    jobarray = user_args.jobarray
+    log_level = user_args.log_level
+
     RQ = RedisQueue('DI_ReadyQueue')
 
     PDSinfoDICT = json.load(open(pds_info, 'r'))
@@ -109,5 +114,4 @@ def main(archive, volume, jobarray, log_level):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main(parse_args()))

--- a/pds_pipelines/FinalJobber.py
+++ b/pds_pipelines/FinalJobber.py
@@ -27,7 +27,10 @@ def parse_args():
     return args
 
 
-def main(log_level, namespace=None):
+def main(user_args):
+    log_level = user_args.log_level
+    namespace = user_args.namespace
+
     if namespace is None:
         namespace = default_namespace
 
@@ -84,5 +87,4 @@ def main(log_level, namespace=None):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main(parse_args()))

--- a/pds_pipelines/FindDI_Ready.py
+++ b/pds_pipelines/FindDI_Ready.py
@@ -94,7 +94,11 @@ def volume_expired(session, archiveID, volume, testing_date=None):
     return expired
 
 
-def main(archive, volume, log_level):
+def main(user_args):
+    archive = user_args.archive
+    volume = user_args.volume
+    log_level = user_args.log_level
+
     PDSinfoDICT = json.load(open(pds_info, 'r'))
     try:
         archiveID = PDSinfoDICT[archive]['archiveid']
@@ -159,5 +163,4 @@ def main(archive, volume, log_level):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main(parse_args()))

--- a/pds_pipelines/IngestProcess.py
+++ b/pds_pipelines/IngestProcess.py
@@ -32,7 +32,9 @@ def parse_args():
     return args
 
 
-def main(log_level, override):
+def main(user_args):
+    log_level = user_args.log_level
+    override = user_args.override
 
     logger = logging.getLogger('Ingest_Process')
     level = logging.getLevelName(log_level)
@@ -172,5 +174,4 @@ def main(log_level, override):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main(parse_args()))

--- a/pds_pipelines/Ingestqueueing.py
+++ b/pds_pipelines/Ingestqueueing.py
@@ -34,7 +34,13 @@ def parse_args():
     return args
 
 
-def main(archive, volume, log_level, search, ingest):
+def main(user_args):
+    archive = user_args.archive
+    volume = user_args.volume
+    search = user_args.search
+    log_level = user_args.log_level
+    ingest = user_args.ingest
+
     RQ_ingest = RedisQueue('Ingest_ReadyQueue')
     RQ_linking = RedisQueue('LinkQueue')
 
@@ -101,5 +107,4 @@ def main(archive, volume, log_level, search, ingest):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main(parse_args()))

--- a/pds_pipelines/LinkArtifacts.py
+++ b/pds_pipelines/LinkArtifacts.py
@@ -22,7 +22,9 @@ def parse_args():
     args = parser.parse_args()
     return args
 
-def main(log_level):
+def main(user_args):
+    log_level = user_args.log_level
+
     RQ = RedisQueue('LinkQueue')
 
     logger = logging.getLogger('LINK_Process')
@@ -104,5 +106,4 @@ def load_pvl(pvl_file_path):
 
 
 if __name__ == '__main__':
-    args = parse_args()
-    main(**vars(args))
+    main(parse_args())

--- a/pds_pipelines/MAPprocess.py
+++ b/pds_pipelines/MAPprocess.py
@@ -34,6 +34,9 @@ def parse_args():
 
 
 def main(key, namespace=None):
+    key = user_args.key
+    namespace = user_args.namespace
+
     if namespace is None:
         namespace = default_namespace
 
@@ -242,5 +245,4 @@ def main(key, namespace=None):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main(parse_args()))

--- a/pds_pipelines/POWprocess.py
+++ b/pds_pipelines/POWprocess.py
@@ -36,6 +36,10 @@ def parse_args():
 
 
 def main(key, namespace=None):
+    key = user_args.key
+    namespace = user_args.namespace
+    print(namespace)
+
     if namespace is None:
         namespace = default_namespace
 
@@ -339,5 +343,4 @@ def main(key, namespace=None):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main(parse_args()))

--- a/pds_pipelines/ServiceFinal.py
+++ b/pds_pipelines/ServiceFinal.py
@@ -52,7 +52,10 @@ def parse_args():
     return args
 
 
-def main(log_level, namespace, key):
+def main(user_args):
+    key = user_args.key
+    namespace = user_args.namespace
+    log_level = user_args.log_level
 
 #***************** Setup Logging **************
     logger = logging.getLogger('ServiceFinal_' + key)
@@ -288,5 +291,4 @@ def main(log_level, namespace, key):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main(parse_args()))

--- a/pds_pipelines/Servicejobber.py
+++ b/pds_pipelines/Servicejobber.py
@@ -577,7 +577,11 @@ def parse_args():
     return args
 
 
-def main(key, norun, namespace=None):
+def main(user_args):
+    key = user_args.key
+    norun = user_args.norun
+    namespace = user_args.namespace
+
     if namespace is None:
         namespace = default_namespace
 
@@ -1029,5 +1033,4 @@ def main(key, norun, namespace=None):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main(parse_args()))

--- a/pds_pipelines/UPC_process.py
+++ b/pds_pipelines/UPC_process.py
@@ -151,7 +151,10 @@ def parse_args():
     return args
 
 
-def main(persist, log_level):
+def main(user_args):
+    persist = user_args.persist
+    log_level = user_args.log_level
+
     try:
         slurm_job_id = os.environ['SLURM_ARRAY_JOB_ID']
         slurm_array_id = os.environ['SLURM_ARRAY_TASK_ID']
@@ -529,5 +532,4 @@ def main(persist, log_level):
     logger.info("UPC processing exited")
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main(parse_args()))

--- a/pds_pipelines/UPCqueueing.py
+++ b/pds_pipelines/UPCqueueing.py
@@ -36,7 +36,12 @@ def parse_args():
     return args
 
 
-def main(archive, volume, search, log_level):
+def main(user_args):
+    archive = user_args.archive
+    volume = user_args.volume
+    search = user_args.search
+    log_level = user_args.log_level
+
     logger = logging.getLogger('UPC_Queueing.' + archive)
     level = logging.getLevelName(log_level)
     logger.setLevel(level)
@@ -82,7 +87,7 @@ def main(archive, volume, search, log_level):
         qf = '%' + search + '%'
         qOBJ = qOBJ.filter(Files.filename.like(qf))
 
-    path = PDSinfoDICT[args.archive]['path']
+    path = PDSinfoDICT[archive]['path']
     if qOBJ:
         addcount = 0
         size = 0
@@ -93,7 +98,7 @@ def main(archive, volume, search, log_level):
         size_free = disk_usage(workarea).free
         if size >= (disk_usage_ratio * size_free ):
             logger.error("Unable to process %s: size %d exceeds %d",
-                         args.volume, size, (size_free * disk_usage_ratio))
+                         volume, size, (size_free * disk_usage_ratio))
             exit()
 
         for element in qOBJ:
@@ -105,7 +110,7 @@ def main(archive, volume, search, log_level):
                 pathlib.Path(dest_path).mkdir(parents=True, exist_ok=True)
                 for f in glob.glob(splitext(fname)[0] + r'.*'):
                     copy2(f, dest_path)
-                RQ.QueueAdd((workarea+element.filename, fid, args.archive))
+                RQ.QueueAdd((workarea+element.filename, fid, archive))
                 addcount = addcount + 1
             except Exception as e:
                 error_queue.QueueAdd(f'Unable to copy / queue {fname}: {e}')
@@ -118,5 +123,4 @@ def main(archive, volume, search, log_level):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main(parse_args()))

--- a/pds_pipelines/batchUPC.py
+++ b/pds_pipelines/batchUPC.py
@@ -22,7 +22,9 @@ def parse_args():
     return args
 
 
-def main(log_level):
+def main(user_args):
+    log_level = user_args.log_level
+
     PDS_info = json.load(open(pds_info, 'r'))
     reddis_queue = RedisQueue('UPC_ReadyQueue')
     logger = logging.getLogger('UPC_Queueing')
@@ -76,5 +78,4 @@ def main(log_level):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    main(**vars(args))
+    main(parse_args())

--- a/pds_pipelines/browse_process.py
+++ b/pds_pipelines/browse_process.py
@@ -125,7 +125,9 @@ def parse_args(self):
     return args
 
 
-def main(log_level):
+def main(user_args):
+    log_level = user_args.log_level
+
     logger = logging.getLogger('Browse_Process')
     level = logging.getLevelName(log_level)
     logger.setLevel(level)
@@ -251,5 +253,4 @@ def main(log_level):
     pds_engine.dispose()
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main(parse_args()))

--- a/pds_pipelines/browse_queueing.py
+++ b/pds_pipelines/browse_queueing.py
@@ -31,7 +31,12 @@ def parse_args():
     args = parser.parse_args()
     return args
 
-def main(archive, volume, search, log_level):
+def main(user_args):
+    archive = user_args.archive
+    volume = user_args.volume
+    search = user_args.search
+    log_level = user_args.log_level
+
     logger = logging.getLogger('Browse_Queueing.' + archive)
     level = logging.getLevelName(log_level)
     logger.setLevel(level)
@@ -75,5 +80,4 @@ def main(archive, volume, search, log_level):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(**vars(args)))
+    sys.exit(main(parse_args()))

--- a/pds_pipelines/db_sync.py
+++ b/pds_pipelines/db_sync.py
@@ -52,7 +52,15 @@ def parse_args():
     return args
 
 
-def main(date, instrument, spacecraft, database, target, loglevel, statistics):
+def main(user_args):
+    date = user_args.date
+    instrument = user_args.instrument
+    spacecraft = user_args.spacecraft
+    database = user_args.database
+    target = user_args.target
+    loglevel = user_args.loglevel
+    statistics = user_args.statistics
+
     logging.basicConfig(level=loglevel)
     source_session, _ = db_connect(upc_db)
 
@@ -383,6 +391,5 @@ def sync_upc_id(source_session, dest_sessions, upc_id, meta_types):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    main(**vars(args))
+    main(parse_args())
 


### PR DESCRIPTION
Moved the parse_args() call into the main() call because args was being treated as a global variable. That is, args could be used in main without passing it in as a parameter.