### PR TITLE
Refactored recipe so that only one method needs be called to add a mission json

### DIFF
--- a/pds_pipelines/Recipe.py
+++ b/pds_pipelines/Recipe.py
@@ -33,6 +33,7 @@ class Recipe(Process):
         Parameters
         ----------
         file : str
+        proc : str
         """
 
         # @TODO use 'with' statement for file read

--- a/pds_pipelines/Recipe.py
+++ b/pds_pipelines/Recipe.py
@@ -15,6 +15,7 @@ from pds_pipelines.config import recipe_base
 
 class Recipe(Process):
     """
+    
     Parameters
     ----------
     Process
@@ -29,11 +30,14 @@ class Recipe(Process):
         self.recipe = []
 
     def AddJsonFile(self, file, proc):
-        """
+        """ Adds a recipe JSON dictionary to the recipe list.
+
         Parameters
         ----------
         file : str
+            The name of the JSON to load.
         proc : str
+            The process pipeline.
         """
 
         # @TODO use 'with' statement for file read
@@ -49,31 +53,36 @@ class Recipe(Process):
             self.recipe.append(processDict)
 
     def addMissionJson(self, mission, proc):
-        """
+        """ Adds a recipe JSON for a specific mission.
+
         Parameters
         ----------
         mission : str
+            The name of the mission.
         proc : str
-
+            The process pipeline.
         """
+
         recipe_json = recipe_base + mission + '.json'
         self.AddJsonFile(recipe_json, proc)
 
     def getRecipe(self):
-        """
+        """ Returns list of recipe dictionaries.
+
         Returns
         -------
         list
-            self.recipe
+            Recipe dictionaries.
         """
         return self.recipe
 
     def getProcesses(self):
-        """
+        """ Returns list of process names.
+
         Returns
         -------
         list
-            processList
+            List of process names.
         """
 
         processList = []
@@ -84,18 +93,22 @@ class Recipe(Process):
         return processList
 
     def AddProcess(self, process):
-        """
+        """ Adds process to recipe.
+
         Parameters
         ----------
         process : str
+            The name of the process pipeline.
         """
         self.recipe.append(process)
 
     def TestgetStep(self, file):
-        """
+        """ 
+
         Parameters
         ----------
-        file : str
+        file : str 
+            The name of the JSON to load.
 
         Returns
         -------

--- a/pds_pipelines/Recipe.py
+++ b/pds_pipelines/Recipe.py
@@ -47,6 +47,17 @@ class Recipe(Process):
 
             self.recipe.append(processDict)
 
+    def addMissionJson(self, mission, proc):
+        """
+        Parameters
+        ----------
+        mission : str
+        proc : str
+
+        """
+        recipe_json = recipe_base + mission + '.json'
+        self.AddJsonFile(recipe_json, proc)
+
     def getRecipe(self):
         """
         Returns
@@ -55,22 +66,6 @@ class Recipe(Process):
             self.recipe
         """
         return self.recipe
-
-    def getRecipeJSON(self, mission):
-        """
-        Parameters
-        ----------
-        mission : str
-
-        Returns
-        -------
-        str
-            output
-        """
-
-        return recipe_base + mission + '.json'
-        #return recipe_dict[mission]
-
 
     def getProcesses(self):
         """

--- a/pds_pipelines/UPC_process.py
+++ b/pds_pipelines/UPC_process.py
@@ -233,12 +233,8 @@ def main(user_args):
         # Update the logger context to include inputfile
         context['inputfile'] = inputfile
 
-        # @TODO refactor this logic.  We're using an object to find a path, returning it,
-        #  then passing it back to the object so that the object can use it.
         recipeOBJ = Recipe()
-        recipe_json = recipeOBJ.getRecipeJSON(archive)
-        #recipe_json = recipeOBJ.getRecipeJSON(getMission(str(inputfile)))
-        recipeOBJ.AddJsonFile(recipe_json, 'upc')
+        recipeOBJ.addMissionJson(archive, 'upc')
 
         infile = os.path.splitext(inputfile)[0] + '.UPCinput.cub'
         logger.debug("Beginning processing on %s\n", inputfile)

--- a/pds_pipelines/browse_process.py
+++ b/pds_pipelines/browse_process.py
@@ -158,8 +158,8 @@ def main(user_args):
             finalpath = makedir(inputfile)
 
             recipeOBJ = Recipe()
-            recip_json = recipeOBJ.getRecipeJSON(archive)
-            recipeOBJ.AddJsonFile(recip_json, 'reduced')
+            recipeOBJ.addMissionJson(archive, 'reduced')
+            
             infile = workarea + os.path.splitext(os.path.basename(inputfile))[0] + '.Binput.cub'
             outfile = workarea + os.path.splitext(os.path.basename(inputfile))[0] + '.Boutput.cub'
             status = 'success'

--- a/pds_pipelines/projectionbrowse_process.py
+++ b/pds_pipelines/projectionbrowse_process.py
@@ -102,8 +102,7 @@ def main():
             finalpath = makedir(inputfile)
 
             recipeOBJ = Recipe()
-            recipe_json = recipeOBJ.getRecipeJSON(mission)
-            recipeOBJ.AddJsonFile(recipe_json, 'reduced')
+            recipeOBJ.addMissionJson(mission, 'reduced')
 
             infile = workarea + \
                 os.path.splitext(os.path.basename(inputfile))[

--- a/pds_pipelines/thumbnail_process.py
+++ b/pds_pipelines/thumbnail_process.py
@@ -143,8 +143,8 @@ def main():
             finalpath = makedir(inputfile)
 
             recipeOBJ = Recipe()
-            recip_json = recipeOBJ.getRecipeJSON(archive)
-            recipeOBJ.AddJsonFile(recip_json, 'reduced')
+            recipeOBJ.addMissionJson(archive, 'reduced')
+            
             infile = workarea + os.path.splitext(os.path.basename(inputfile))[0] + '.Tinput.cub'
             outfile = workarea + os.path.splitext(os.path.basename(inputfile))[0] + '.Toutput.cub'
             status = 'success'


### PR DESCRIPTION
Added  addMissionJson that combines the two method calls that each script was doing. Removed getRecipeJSON since no files are using it now. Left in AddJsonFile since ServiceJobber is using it.

closes https://github.com/USGS-Astrogeology/PDS-Pipelines/issues/313 