### PR TITLE
Recipe Rendering with Jinja Templates

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
     - redis
     - pip
     - pytest
+    - jinja2
     - mock
     - shapely
     - sqlalchemy-utils

--- a/pds_pipelines/process.py
+++ b/pds_pipelines/process.py
@@ -13,10 +13,10 @@ class Process(object):
     ----------
     ProcessName : str
     """
-    def __init__(self):
+    def __init__(self, process="", args=None):
 
-        self.processName = ""
-        self.process = None
+        self.processName = process
+        self.process = {process: args}
 
     def Process2JSON(self):
         """
@@ -179,10 +179,6 @@ class Process(object):
         """
         testDict = {param: newValue}
 
-        test = []
-        test.append(param)
-        test.append(newValue)
-
         for k, v in testDict.items():
             self.process[self.processName][str(k)] = str(v)
 
@@ -201,8 +197,11 @@ class Process(object):
                    'signedword': 'Int16',
                    'real': 'Float32'
                    }
-
-        return bitDICT[ibit]
+        try:
+            return bitDICT[ibit]
+        except KeyError:
+            raise Exception(f"Unsupported ibit type given {ibit}. " +
+                            f"Currently supported bit types are {list(bitDICT.keys())}")
 
     def GDAL_Creation(self, format):
         """
@@ -220,5 +219,8 @@ class Process(object):
                  'JP2KAK': 'quality=100',
                  'GTiff': 'bigtiff=if_safer'
                  }
-
-        return cDICT[format]
+        try:
+            return cDICT[format]
+        except KeyError:
+            raise Exception(f"Unsupported format {format}. " +
+                            f"Currently supported bit types are {list(cDICT.keys())}")

--- a/pds_pipelines/recipe.py
+++ b/pds_pipelines/recipe.py
@@ -39,9 +39,8 @@ class Recipe(Process):
         proc : str
             The process pipeline.
         """
-
-        # @TODO use 'with' statement for file read
-        testjson = json.loads(open(file).read(), object_pairs_hook=OrderedDict)
+        with open(file, 'r') as fp:
+            testjson = json.loads(fp, object_pairs_hook=OrderedDict)
 
         for IP in testjson[proc]['recipe']:
             process = str(IP)

--- a/pds_pipelines/tests/test_process.py
+++ b/pds_pipelines/tests/test_process.py
@@ -1,0 +1,103 @@
+from pds_pipelines.process import Process
+
+import json
+
+import pytest
+from unittest.mock import patch, PropertyMock, Mock
+from unittest import mock
+
+@pytest.fixture
+def empty_process_obj():
+    process = Process()
+    return process
+
+@pytest.fixture
+def process_obj():
+    process = Process()
+    json_dict = {'data2isis': {'from_':'some_image.img', 'to': 'some_image.cub'},
+                 'spiceinit': {'from_':'some_image.cub'}}
+    json_str = json.dumps(json_dict)
+    process.JSON2Process(json_str)
+    return process
+
+@pytest.fixture
+def json_dict():
+    json_dict = {'data2isis': {'from_':'some_image.img', 'to': 'some_image.cub'},
+                 'spiceinit': {'from_':'some_image.cub'}}
+    return json_dict
+
+def test_default_process(empty_process_obj):
+    assert len(empty_process_obj.getProcess().keys()) == 1
+    assert empty_process_obj.getProcess()[''] == None
+    assert empty_process_obj.getProcessName() == ''
+
+def test_process_2_json(process_obj, json_dict):
+    process_str = process_obj.Process2JSON()
+    assert process_str == json.dumps(json_dict)
+
+# This seems "wrong"
+def test_json_2_process(empty_process_obj, json_dict):
+    json_str = json.dumps(json_dict)
+    empty_process_obj.JSON2Process(json_str)
+    assert empty_process_obj.getProcess().keys() == json_dict.keys()
+    assert empty_process_obj.getProcessName() == 'spiceinit'
+
+def test_set_process(process_obj):
+    assert process_obj.getProcessName() == 'spiceinit'
+    process_obj.setProcess('Banana')
+    assert process_obj.getProcessName() == 'Banana'
+    assert len(process_obj.getProcess().keys()) == 2
+
+# Reduces the number of processes in the process object from 2 to 1
+# Also seems "wrong"
+def test_change_process(process_obj):
+    assert process_obj.getProcessName() == 'spiceinit'
+    assert len(process_obj.getProcess()) == 2
+    process_obj.ChangeProcess('Banana')
+    assert len(process_obj.getProcess()) == 1
+    assert process_obj.getProcessName() == 'Banana'
+    assert list(process_obj.getProcess().keys()) == ['Banana']
+    assert list(process_obj.getProcess()['Banana'].keys()) == ['from_']
+
+# Reduces the number of processes from the json dict from 2 to 1
+# Also seems "wrong"
+def test_process_from_recipe(empty_process_obj, json_dict):
+    recipe = [{i: json_dict[i]} for i in json_dict]
+    empty_process_obj.ProcessFromRecipe('spiceinit', recipe)
+    assert empty_process_obj.getProcessName() == 'spiceinit'
+    assert list(empty_process_obj.getProcess().keys()) == ['spiceinit']
+
+def test_update_parameter(process_obj):
+    assert process_obj.getProcess()['data2isis']['from_'] == 'some_image.img'
+    assert process_obj.getProcess()['spiceinit']['from_'] == 'some_image.cub'
+    process_obj.updateParameter('from_', 'some_other_image.cub')
+    assert process_obj.getProcess()['data2isis']['from_'] == 'some_image.img'
+    assert process_obj.getProcess()['spiceinit']['from_'] == 'some_other_image.cub'
+
+def test_new_process(process_obj):
+    assert process_obj.getProcessName() == 'spiceinit'
+    process = 'Banana'
+    process_obj.newProcess(process)
+    assert process_obj.getProcessName() == process
+    assert len(process_obj.getProcess()[process].keys()) == 0
+
+def test_add_parameter(process_obj):
+    assert len(process_obj.getProcess()['spiceinit'].keys()) == 1
+    process_obj.AddParameter('ckrecon', True)
+    assert len(process_obj.getProcess()['spiceinit'].keys()) == 2
+
+def test_gdal_ibit(process_obj):
+    gdal_bit_type = process_obj.GDAL_OBit('unsignedbyte')
+    assert gdal_bit_type == 'Byte'
+
+@pytest.mark.xfail(raises=Exception)
+def test_gdal_ibit_fail(process_obj):
+    process_obj.GDAL_OBit('apple')
+
+def test_gdal_creation(process_obj):
+    gdal_bit_type = process_obj.GDAL_Creation('JPEG')
+    assert gdal_bit_type == 'quality=100'
+
+@pytest.mark.xfail(raises=Exception)
+def test_gdal_creation_fail(process_obj):
+    process_obj.GDAL_Creation('apple')

--- a/pds_pipelines/tests/test_upc.py
+++ b/pds_pipelines/tests/test_upc.py
@@ -258,13 +258,14 @@ def test_search_terms_no_datafile(mocked_product_id, mocked_keyword, mocked_init
 
 @patch('pds_pipelines.upc_keywords.UPCkeywords.__init__', return_value = None)
 def test_json_keywords_insert(mocked_init, session, session_maker, pds_label):
+    logger = logging.getLogger('UPC_Process')
     upc_id = cam_info_dict['upcid']
 
     models.DataFiles.create(session, upcid = upc_id)
 
     with patch('pds_pipelines.upc_keywords.UPCkeywords.label', new_callable=PropertyMock) as mocked_label:
         mocked_label.return_value = pds_label
-        create_json_keywords_record(pds_label, upc_id, '/Path/to/my/cube.cub', 'No Failures', session_maker)
+        create_json_keywords_record(pds_label, upc_id, '/Path/to/my/cube.cub', 'No Failures', session_maker, logger)
 
     resp = session.query(JsonKeywords).filter(JsonKeywords.upcid == upc_id).first()
     resp_json = resp.jsonkeywords
@@ -274,12 +275,13 @@ def test_json_keywords_insert(mocked_init, session, session_maker, pds_label):
     assert resp_json['SPACECRAFT_NAME'] == pds_label['SPACECRAFT_NAME']
 
 def test_json_keywords_exception(session, session_maker):
+    logger = logging.getLogger('UPC_Process')
     upc_id = cam_info_dict['upcid']
     models.DataFiles.create(session, upcid = upc_id)
 
     input_cube = '/Path/to/my/cube.cub'
     error_message = 'Got to exception.'
-    create_json_keywords_record("", upc_id, input_cube, error_message, session_maker)
+    create_json_keywords_record("", upc_id, input_cube, error_message, session_maker, logger)
     resp = session.query(JsonKeywords).filter(JsonKeywords.upcid == upc_id).first()
     resp_json = resp.jsonkeywords
     assert resp_json['errortype'] == error_message
@@ -289,12 +291,13 @@ def test_json_keywords_exception(session, session_maker):
 
 @patch('pds_pipelines.upc_keywords.UPCkeywords.__init__', return_value = None)
 def test_json_keywords_no_datafile(mocked_init, session, session_maker, pds_label):
+    logger = logging.getLogger('UPC_Process')
     upc_id = cam_info_dict['upcid']
 
     with pytest.raises(sqlalchemy.exc.IntegrityError),\
     patch('pds_pipelines.upc_keywords.UPCkeywords.label', new_callable=PropertyMock) as mocked_label:
         mocked_label.return_value = pds_label
-        create_json_keywords_record(pds_label, upc_id, '/Path/to/my/cube.cub', 'No Failures', session_maker)
+        create_json_keywords_record(pds_label, upc_id, '/Path/to/my/cube.cub', 'No Failures', session_maker, logger)
 
 def test_generate_processes():
     logger = logging.getLogger('UPC_Process')

--- a/pds_pipelines/tests/test_upc.py
+++ b/pds_pipelines/tests/test_upc.py
@@ -320,7 +320,7 @@ def test_process_isis():
 
     processes = {'getsn': {'from_': '/Path/to/some/cube.cub'}}
 
-    failing_command = process(processes, '/', '/', logger)
+    failing_command = process(processes, '/', logger)
     assert failing_command == ''
 
 def test_bad_process_isis():
@@ -328,5 +328,5 @@ def test_bad_process_isis():
 
     processes = {'spiceinit': {'from_': '/Path/to/some/cube.cub'}}
 
-    failing_command = process(processes, '/', '/', logger)
+    failing_command = process(processes, '/', logger)
     assert failing_command == 'spiceinit'

--- a/pds_pipelines/upc_process.py
+++ b/pds_pipelines/upc_process.py
@@ -10,6 +10,7 @@ from ast import literal_eval
 import pytz
 import pvl
 import argparse
+import jinja2
 
 from pysis import isis
 from pysis.exceptions import ProcessError
@@ -22,7 +23,7 @@ from pds_pipelines.upc_keywords import UPCkeywords
 from pds_pipelines.db import db_connect
 from pds_pipelines.models import pds_models
 from pds_pipelines.models.upc_models import SearchTerms, Targets, Instruments, DataFiles, JsonKeywords, BaseMixin
-from pds_pipelines.config import pds_log, pds_info, workarea, keyword_def, pds_db, upc_db, lock_obj, upc_error_queue, web_base, archive_base
+from pds_pipelines.config import pds_log, pds_info, workarea, keyword_def, pds_db, upc_db, lock_obj, upc_error_queue, web_base, archive_base, recipe_base
 
 from sqlalchemy import and_
 
@@ -182,7 +183,7 @@ def get_instrument_id(label, session_maker):
 
     if not instrument_name:
         return None
-    
+
     # PDS3 does not require a keyword to hold spacecraft name,
     #  and PDS3 defines several (often interchangeable) keywords to
     #  hold spacecraft name, so try each of them in preferred order and grab the first match.
@@ -360,7 +361,7 @@ def create_search_terms_record(label, cam_info_pvl, upc_id, input_cube, session_
         session.commit()
     session.close()
 
-def create_json_keywords_record(cam_info_pvl, upc_id, input_file, failing_command, session_maker):
+def create_json_keywords_record(cam_info_pvl, upc_id, input_file, failing_command, session_maker, logger):
     """
     Creates a new SearchTerms record through values from a given caminfo file
     and adds the new record to the database
@@ -387,6 +388,7 @@ def create_json_keywords_record(cam_info_pvl, upc_id, input_file, failing_comman
     try:
         keywordsOBJ = UPCkeywords(cam_info_pvl)
     except Exception as e:
+        logger.debug(f"Failed to create upc keywords with: {e}")
         keywordsOBJ = None
 
     json_keywords_attributes = dict.fromkeys(JsonKeywords.__table__.columns.keys(), None)
@@ -397,7 +399,7 @@ def create_json_keywords_record(cam_info_pvl, upc_id, input_file, failing_comman
         json_keywords = json.dumps(keywordsOBJ.label, indent=4, sort_keys=True, default=str)
         json_keywords = json.loads(json_keywords)
     except Exception as e:
-        print(e)
+        logger.debug(f"Failed to load json keywords with: {e}")
         err_dict = {}
         err_dict['processdate'] = datetime.datetime.now(pytz.utc).strftime(
             "%Y-%m-%d %H:%M:%S")
@@ -423,78 +425,45 @@ def create_json_keywords_record(cam_info_pvl, upc_id, input_file, failing_comman
         session.commit()
     session.close()
 
-def generate_isis_processes(inputfile, archive, logger):
+def generate_processes(inputfile, archive, logger):
     logger.info('Starting Process: %s', inputfile)
-
-    recipeOBJ = Recipe()
-    recipeOBJ.addMissionJson(archive, 'upc')
 
     # Working directory for processing should be same as inputfile
     pwd = os.path.dirname(inputfile)
-    
-    infile = os.path.splitext(inputfile)[0] + '.UPCinput.cub'
+
     logger.debug("Beginning processing on %s\n", inputfile)
+    no_extension_inputfile = os.path.splitext(inputfile)[0]
+    cam_info_file = os.path.splitext(inputfile)[0] + '.caminfo.pvl'
 
-    outfile = os.path.splitext(inputfile)[0] + '.UPCoutput.cub'
-    caminfoOUT = os.path.splitext(inputfile)[0] + '_caminfo.pvl'
+    recipe_file = recipe_base + "/" + archive + '.json'
+    with open(recipe_file) as fp:
+        json_str = json.dumps(json.load(fp)['upc']['recipe'])
 
-    processes = []
-    # Iterate through each process listed in the recipe
-    for item in recipeOBJ.getProcesses():
-        # If any of the processes failed, discontinue processing
-        processOBJ = Process()
-        processOBJ.ProcessFromRecipe(item, recipeOBJ.getRecipe())
-        # Handle processing based on string description.
-        if '2isis' in item:
-            processOBJ.updateParameter('from_', inputfile)
-            processOBJ.updateParameter('to', infile)
-        elif item == 'thmproc':
-            processOBJ.updateParameter('from_', inputfile)
-            processOBJ.updateParameter('to', infile)
-            # thmproc writes intermediate files to os.cwd(),
-            # so working directory must be changed to match
-            # paths on next lines before thmproc actually called
-            thmproc_odd = str(os.path.splitext(
-                inputfile)[0]) + '.UPCinput.raw.odd.cub'
-            thmproc_even = str(os.path.splitext(
-                inputfile)[0]) + '.UPCinput.raw.even.cub'
-        elif item == 'handmos':
-            processOBJ.updateParameter('from_', thmproc_even)
-            processOBJ.updateParameter('mosaic', thmproc_odd)
-            # Anticipate the mosaicked image being passed to footprintinit next
-            #  and re-reference accordingly
-            infile = thmproc_odd
-        elif item == 'spiceinit':
-            processOBJ.updateParameter('from_', infile)
-        elif item == 'footprintinit':
-            processOBJ.updateParameter('from_', infile)
-        elif item == 'caminfo':
-            processOBJ.updateParameter('from_', infile)
-            processOBJ.updateParameter('to', caminfoOUT)
-        else:
-            processOBJ.updateParameter('from_', infile)
-            processOBJ.updateParameter('to', outfile)
+    template = jinja2.Template(json_str)
+    recipe_str = template.render(inputfile=inputfile,
+                                 no_extension_inputfile=no_extension_inputfile,
+                                 cam_info_file=cam_info_file)
+    processes = json.loads(recipe_str)
 
-        processes.append(processOBJ)
+    return processes, no_extension_inputfile, cam_info_file, pwd
 
-    return processes, infile, caminfoOUT, pwd
-
-def process_isis(processes, workarea, pwd, logger):
-    # iterate through functions listed in process obj
+def process(processes, workarea, pwd, logger):
+    # iterate through functions from the processes dictionary
     failing_command = ''
-    for process in processes:
-        for command, keywargs in process.getProcess().items():
-            # load a function into func
-            func = getattr(isis, command)
-            try:
-                os.chdir(pwd)
-                # execute function
-                func(**keywargs)
+    for command, keywargs in processes.items():
+        # load a function into func
+        func = getattr(isis, command)
+        try:
+            os.chdir(pwd)
+            # execute function
+            logger.debug("Running %s", command)
+            func(**keywargs)
 
-            except ProcessError as e:
-                logger.error("%s", e)
-                failing_command = command
-                break
+        except ProcessError as e:
+            logger.debug("%s", e)
+            logger.debug("%s", e.stderr)
+            failing_command = command
+            break
 
     return failing_command
 
@@ -522,6 +491,7 @@ def main(user_args):
     except:
         slurm_job_id = ''
         slurm_array_id = ''
+
     inputfile = ''
     context = {'job_id': slurm_job_id, 'array_id':slurm_array_id, 'inputfile': inputfile}
     logger = logging.getLogger('UPC_Process')
@@ -567,19 +537,19 @@ def main(user_args):
         # Update the logger context to include inputfile
         context['inputfile'] = inputfile
 
-        processes, infile, caminfoOUT, pwd = generate_isis_processes(inputfile, archive, logger)
-        failing_command = process_isis(processes, workarea, pwd, logger)
+        processes, infile, caminfoOUT, pwd = generate_processes(inputfile, archive, logger)
+        failing_command = process(processes, workarea, pwd, logger)
 
         pds_label = pvl.load(inputfile)
- 
+
         ######## Generate DataFiles Record ########
         upc_id = create_datafiles_record(pds_label, edr_source, infile, upc_session_maker)
- 
+
         ######## Generate SearchTerms Record ########
         create_search_terms_record(pds_label, caminfoOUT, upc_id, infile, upc_session_maker)
 
         ######## Generate JsonKeywords Record ########
-        create_json_keywords_record(caminfoOUT, upc_id, inputfile, failing_command, upc_session_maker)
+        create_json_keywords_record(caminfoOUT, upc_id, inputfile, failing_command, upc_session_maker, logger)
 
         try:
             session.flush()
@@ -590,9 +560,9 @@ def main(user_args):
         AddProcessDB(pds_session, fid, True)
         pds_session.close()
 
-        if not persist:
-            os.remove(infile)
-            os.remove(caminfoOUT)
+        # if not persist:
+        #     os.remove(infile)
+        #     os.remove(caminfoOUT)
 
         # Disconnect from the engines
         pds_engine.dispose()

--- a/recipe/new/messenger.json
+++ b/recipe/new/messenger.json
@@ -4,16 +4,16 @@
     "upc": {
         "recipe": {
             "mdis2isis": {
-                "from_": "value",
-                "to": "value"
+                "from_": "{{inputfile}}",
+                "to": "{{no_extension_inputfile}}.cub"
             },
             "spiceinit": {
-                "from_": "value",
+                "from_": "{{no_extension_inputfile}}.cub",
                 "cknadir": "yes",
                 "cksmithed": "yes"
             },
             "footprintinit": {
-                "from_": "value",
+                "from_": "{{no_extension_inputfile}}.cub",
                 "increaseprecision": "yes",
                 "inctype": "vertices",
                 "numvertices": "40",
@@ -21,8 +21,8 @@
                 "maxincidence": "120.0"
             },
             "caminfo": {
-                "from_": "value",
-                "to": "value",
+                "from_": "{{no_extension_inputfile}}.cub",
+                "to": "{{cam_info_file}}",
                 "geometry": "yes",
                 "isislabel": "yes",
                 "originallabel": "yes",

--- a/recipe/new/mo_themis_vis_edr.json
+++ b/recipe/new/mo_themis_vis_edr.json
@@ -4,25 +4,25 @@
     "upc": {
         "recipe": {
             "thmproc": {
-                "from_": "value",
-                "to": "value",
+                "from_": "{{inputfile}}",
+                "to": "{{no_extension_inputfile}}.cub",
                 "mapping": "no",
                 "remove": "no"
             },
             "handmos": {
-                "from_": "value",
-                "mosaic": "value",
+                "from_": "{{no_extension_inputfile}}.raw.even.cub",
+                "mosaic": "{{no_extension_inputfile}}.raw.odd.cub",
                 "priority": "beneath"
             },
             "footprintinit": {
-                "from_": "value",
+                "from_": "{{no_extension_inputfile}}.raw.odd.cub",
                 "increaseprecision": "yes",
                 "inctype": "vertices",
                 "numvertices": "20"
             },
             "caminfo": {
-                "from_": "value",
-                "to": "value",
+                "from_": "{{no_extension_inputfile}}.raw.odd.cub",
+                "to": "{{cam_info_file}}",
                 "geometry": "yes",
                 "isislabel": "yes",
                 "originallabel": "no",


### PR DESCRIPTION
Changes recipe construction/processing to use jinja templates. 

Any recipe template is filled in with given values from the script, currently using the following:
- inputfile (Original source image ie. QUB, img, IMG, etc.)
- no_extension_inputfile (Original source image without the extension)
- cam_info_file (Output file to be used for cam info)

This set of parameters puts more onus on recipe creators to handle proper inputs and outputs and to know exactly how their recipe/pipeline works. In this PR are two updated pipelines for themis_vis and messenger. The themis_vis pipeline is a tested and true pipeline but exemplifies why someone needs to understand the pipeline as it uses an intermediate output from thmproc to run in the rest of the pipeline.

Closes #374 