### PR TITLE
Remove old UPC queueing in ingest_process.py

### DIFF
--- a/pds_pipelines/ingest_process.py
+++ b/pds_pipelines/ingest_process.py
@@ -55,13 +55,13 @@ def main(user_args):
     RQ_lock.add({RQ_main.id_name: '1'})
     RQ_work = RedisQueue('Ingest_WorkQueue')
 
-    RQ_upc = RedisQueue('UPC_ReadyQueue')
-    RQ_thumb = RedisQueue('Thumbnail_ReadyQueue')
-    RQ_browse = RedisQueue('Browse_ReadyQueue')
+    # RQ_upc = RedisQueue('UPC_ReadyQueue')
+    # RQ_thumb = RedisQueue('Thumbnail_ReadyQueue')
+    # RQ_browse = RedisQueue('Browse_ReadyQueue')
 
-    logger.info("UPC Queue: %s", RQ_upc.id_name)
-    logger.info("Thumbnail Queue: %s", RQ_thumb.id_name)
-    logger.info("Browse Queue: %s", RQ_browse.id_name)
+    # logger.info("UPC Queue: %s", RQ_upc.id_name)
+    # logger.info("Thumbnail Queue: %s", RQ_thumb.id_name)
+    # logger.info("Browse Queue: %s", RQ_browse.id_name)
 
     try:
         Session, engine = db_connect(pds_db)
@@ -136,11 +136,11 @@ def main(user_args):
                 session.merge(ingest_entry)
                 session.flush()
 
-                if upcflag:
-                    RQ_upc.QueueAdd((inputfile, ingest_entry.fileid, archive))
-                    RQ_thumb.QueueAdd((inputfile, ingest_entry.fileid, archive))
-                    RQ_browse.QueueAdd((inputfile, ingest_entry.fileid, archive))
-                    #RQ_pilotB.QueueAdd((inputfile,ingest_entry.fileid, archive))
+                # if upcflag:
+                #     RQ_upc.QueueAdd((inputfile, ingest_entry.fileid, archive))
+                #     RQ_thumb.QueueAdd((inputfile, ingest_entry.fileid, archive))
+                #     RQ_browse.QueueAdd((inputfile, ingest_entry.fileid, archive))
+                #     #RQ_pilotB.QueueAdd((inputfile,ingest_entry.fileid, archive))
 
                 RQ_work.QueueRemove(inputfile)
 

--- a/pds_pipelines/ingest_process.py
+++ b/pds_pipelines/ingest_process.py
@@ -55,14 +55,6 @@ def main(user_args):
     RQ_lock.add({RQ_main.id_name: '1'})
     RQ_work = RedisQueue('Ingest_WorkQueue')
 
-    # RQ_upc = RedisQueue('UPC_ReadyQueue')
-    # RQ_thumb = RedisQueue('Thumbnail_ReadyQueue')
-    # RQ_browse = RedisQueue('Browse_ReadyQueue')
-
-    # logger.info("UPC Queue: %s", RQ_upc.id_name)
-    # logger.info("Thumbnail Queue: %s", RQ_thumb.id_name)
-    # logger.info("Browse Queue: %s", RQ_browse.id_name)
-
     try:
         Session, engine = db_connect(pds_db)
         session = Session()
@@ -135,12 +127,6 @@ def main(user_args):
 
                 session.merge(ingest_entry)
                 session.flush()
-
-                # if upcflag:
-                #     RQ_upc.QueueAdd((inputfile, ingest_entry.fileid, archive))
-                #     RQ_thumb.QueueAdd((inputfile, ingest_entry.fileid, archive))
-                #     RQ_browse.QueueAdd((inputfile, ingest_entry.fileid, archive))
-                #     #RQ_pilotB.QueueAdd((inputfile,ingest_entry.fileid, archive))
 
                 RQ_work.QueueRemove(inputfile)
 


### PR DESCRIPTION
ingest_process.py used to add to the UPC_ReadyQueue until upc_queueing.py was added. The code for queueing still remained in ingest_process.py and caused problems since the logic for queueing and ingesting changed. 

closes #369 