### PR TITLE
Removed extra try/except in upc_process

### DIFF
--- a/pds_pipelines/tests/test_upc.py
+++ b/pds_pipelines/tests/test_upc.py
@@ -188,7 +188,7 @@ def test_datafiles_no_label(mocked_pds_id, mocked_isis_id, session, session_make
 def test_datafiles_no_isisid(mocked_pds_id, session, session_maker, pds_label):
     # Since we mock getsn above, make it throw an exception here so we can test
     # when there is no ISIS ID.
-    with patch('pysis.isis.getsn', side_effect=Exception('ProcessError')):
+    with patch('pysis.isis.getsn', side_effect=ProcessError(1, ['getsn'], '', '')):
         upc_id = create_datafiles_record(pds_label, '/Path/to/label/location/label.lbl', '/Path/to/my/cube.cub', session_maker)
     resp = session.query(models.DataFiles).filter(models.DataFiles.upcid==upc_id).first()
     assert resp.isisid == None

--- a/pds_pipelines/tests/test_upc.py
+++ b/pds_pipelines/tests/test_upc.py
@@ -188,7 +188,7 @@ def test_datafiles_no_label(mocked_pds_id, mocked_isis_id, session, session_make
 def test_datafiles_no_isisid(mocked_pds_id, session, session_maker, pds_label):
     # Since we mock getsn above, make it throw an exception here so we can test
     # when there is no ISIS ID.
-    with patch('pysis.isis.getsn', side_effect=Exception('AttributeError')):
+    with patch('pysis.isis.getsn', side_effect=Exception('ProcessError')):
         upc_id = create_datafiles_record(pds_label, '/Path/to/label/location/label.lbl', '/Path/to/my/cube.cub', session_maker)
     resp = session.query(models.DataFiles).filter(models.DataFiles.upcid==upc_id).first()
     assert resp.isisid == None

--- a/pds_pipelines/upc_process.py
+++ b/pds_pipelines/upc_process.py
@@ -68,7 +68,12 @@ def getISISid(infile):
     newisisSerial : str
         The serial number of the input file.
     """
-    serial_num = available_modules['isis'].getsn(from_=infile)
+    try:
+    	serial_num = available_modules['isis'].getsn(from_=infile)
+    except(ProcessError, KeyError):
+        # If either isis was not imported or a serial number could not be
+        # generated from the infile set the serial number to an empty string
+        return None
 
     # in later versions of getsn, serial_num is returned as bytes
     if isinstance(serial_num, bytes):
@@ -256,15 +261,7 @@ def create_datafiles_record(label, edr_source, input_cube, session_maker):
     datafile_attributes['detached_label'] = d_label
 
     # Attemp to get the ISIS serial from the cube
-    try:
-        isis_id = getISISid(input_cube)
-        
-    except(ProcessError, KeyError):
-        # If either isis was not imported or a serial number could not be
-        # generated from the infile set the serial number to an empty string
-        isis_id = None
-
-    datafile_attributes['isisid'] = isis_id
+    datafile_attributes['isisid'] = getISISid(input_cube)
 
     # Attemp to get the product id from the cube
     try:

--- a/pds_pipelines/upc_process.py
+++ b/pds_pipelines/upc_process.py
@@ -68,12 +68,8 @@ def getISISid(infile):
     newisisSerial : str
         The serial number of the input file.
     """
-    try:
-        serial_num = available_modules['isis'].getsn(from_=infile)
-    except (ProcessError, KeyError) as e:
-        # If either isis was not imported or a serial number could not be
-        # generated from the infile set the serial number to an empty string
-        serial_num = ''
+    serial_num = available_modules['isis'].getsn(from_=infile)
+
     # in later versions of getsn, serial_num is returned as bytes
     if isinstance(serial_num, bytes):
         serial_num = serial_num.decode()
@@ -262,7 +258,10 @@ def create_datafiles_record(label, edr_source, input_cube, session_maker):
     # Attemp to get the ISIS serial from the cube
     try:
         isis_id = getISISid(input_cube)
-    except:
+        
+    except(ProcessError, KeyError):
+        # If either isis was not imported or a serial number could not be
+        # generated from the infile set the serial number to an empty string
         isis_id = None
 
     datafile_attributes['isisid'] = isis_id


### PR DESCRIPTION
If an isis id is not found or pyisis is not imported, than we set the isisid to None. I don't know if we need to catch an Attribute Error. I think I originally wrote that test and may have chosen an error that wasn't Key or Process just to get isis id set to None.