### PR TITLE
service_final.py: Correctly encode error XML as string before writing…

### DIFF
--- a/pds_pipelines/service_final.py
+++ b/pds_pipelines/service_final.py
@@ -105,12 +105,13 @@ def main(user_args):
 
         fh = BytesIO()
         tree.write(fh, encoding='utf-8', xml_declaration=True)
-        testval = DBQO.addErrors(key , fh.getvalue())
+        errorxml = str(fh.getvalue(), 'utf-8').replace("\n","")
+        testval = DBQO.addErrors(key , errorxml)
         if testval == 'Success':
             logger.info('Error XML add to JOBS DB')
         elif testval == 'Error':
             logger.error('Addin Error XML to JOBS DB: Error')
-        print(fh.getvalue())
+        print(errorxml)
 
     Fdir = pow_map2_base + infoHash.Service() + '/' + key
     Wpath = scratch + key


### PR DESCRIPTION
… to jobs database

This is essentially a 1 line fix. The solution I came up with was to just wrap the value of the bytestream in `str()`. I also had to remove any lingering `\n` characters in the error string.

Fixes #425 