### PR TITLE
Skip filter logic if only one candidate key is found

### DIFF
--- a/pds_pipelines/service_job_manager.py
+++ b/pds_pipelines/service_job_manager.py
@@ -63,13 +63,14 @@ class jobXML(object):
 
         # try to filter list based on upc_reqs.  If upc_reqs isn't specified, just skip the filtering step
         # ps can't use 'filter' because not all elements have upc_reqs, so they may raise exceptions.
-        for item in candidates:
-            try:
-                if not all(x in file_name for x in self.pds_info[item]['upc_reqs']):
-                    candidates.remove(item)
-            except KeyError:
-                # Intentionally left blank.  Unspecified upc_reqs is valid -- there's just nothing to do for those elements
-                pass
+        if len(candidates) > 1:
+            for item in candidates:
+                try:
+                    if not all(x in file_name for x in self.pds_info[item]['upc_reqs']):
+                        candidates.remove(item)
+                except KeyError:
+                    # Intentionally left blank.  Unspecified upc_reqs is valid -- there's just nothing to do for those elements
+                    pass
 
         # If multiple candidates still exist, then it is not possible to uniquely identify the clean name
         if len(candidates) > 1:


### PR DESCRIPTION
Since this is a process-breaking issue, I decided to take the low hanging fruit and get this pushed out quickly.

It's worth looking into alternate fixes -- probably something that doesn't use upc_reqs.  upc_reqs isn't really supposed to be a mechanism for uniquely identifying archives, but it initially seemed like it was sufficient for that purpose.  The existence of this issue seems to suggest otherwise.

On the other hand, the upc_reqs based filtering can be considered a "last ditch effort" in that it provides an additional layer of information that can be used to uniquely identify an archive that is otherwise not uniquely identifiable.

Closes #443 