### PR TITLE
Replaced hardcoded paths with archive_base and derived_base

### DIFF
--- a/pds_pipelines/browse_process.py
+++ b/pds_pipelines/browse_process.py
@@ -20,7 +20,7 @@ from pds_pipelines.process import Process
 from pds_pipelines.db import db_connect
 from pds_pipelines.models.upc_models import MetaString, DataFiles
 from pds_pipelines.models.pds_models import ProcessRuns
-from pds_pipelines.config import pds_log, pds_info, workarea, pds_db, upc_db, lock_obj, upc_error_queue
+from pds_pipelines.config import pds_log, pds_info, workarea, pds_db, upc_db, lock_obj, upc_error_queue, archive_base, derived_base
 from pds_pipelines.upc_process import get_tid
 
 def getISISid(infile):
@@ -61,7 +61,7 @@ def makedir(inputfile):
 #    pdb.set_trace()
 
     temppath = os.path.dirname(inputfile).lower()
-    finalpath = temppath.replace('/pds_san/pds_archive/', '/pds_san/PDS_Derived/UPC/images/')
+    finalpath = temppath.replace(archive_base, derived_base)
 
     if not os.path.exists(finalpath):
         try:
@@ -81,7 +81,7 @@ def DB_addURL(session, isisSerial, inputfile, tid):
 
     if str(Qobj.isisid) == str(isisSerial):
 
-        outputfile = inputfile.replace('/pds_san/PDS_Derived/UPC/images/', '$browse_server/')
+        outputfile = inputfile.replace(derived_base, '$browse_server/')
 
         print(Qobj.upcid)
         DBinput = MetaString(upcid=Qobj.upcid,

--- a/pds_pipelines/config.py
+++ b/pds_pipelines/config.py
@@ -26,6 +26,7 @@ pow_map2_base = '/pds_san/PDS_Services/'
 
 web_base = 'https://pdsimage.wr.usgs.gov/Missions/'
 archive_base = '/pds_san/PDS_Archive/'
+derived_base = '/pds_san/PDS_Derived/UPC/images/'
 link_dest = '/pds_san/PDS_Archive_Links/'
 
 # Recipe base path

--- a/pds_pipelines/thumbnail_process.py
+++ b/pds_pipelines/thumbnail_process.py
@@ -61,7 +61,7 @@ def makedir(inputfile):
     temppath = os.path.dirname(inputfile).lower()
     # @TODO change finalpath back to production path
     #finalpath = temppath.replace('/pds_san/pds_archive/', '/home/arsanders/PDS-Pipelines/products/thumb/')
-    finalpath = temppath.replace('/pds_san/pds_archive/', '/pds_san/PDS_Derived/UPC/images/')
+    finalpath = temppath.replace(archive_base, derived_base)
 
     if not os.path.exists(finalpath):
         try:
@@ -79,7 +79,7 @@ def DB_addURL(session, isisSerial, inputfile, tid):
 
     if str(Qobj.isisid) == str(isisSerial):
 
-        outputfile = inputfile.replace('/pds_san/PDS_Derived/UPC/images/', '$thumbnail_server/')
+        outputfile = inputfile.replace(derived_base, '$thumbnail_server/')
 
         print(Qobj.upcid)
         DBinput = MetaString(upcid=Qobj.upcid,


### PR DESCRIPTION
Replaced hardcoded paths with archive_base and derived_base.

***Note that config files will require an update following merge of this PR***
This is as simple as adding ```derived_base = '/pds_san/PDS_Derived/UPC/images/'``` to the config file.

Closes #440 