### PR TITLE
pow_process.py: Pass band info correctly

### DIFF
--- a/pds_pipelines/pow_process.py
+++ b/pds_pipelines/pow_process.py
@@ -78,13 +78,15 @@ def main(user_args):
         if '+' in jobFile:
             bandSplit = jobFile.split('+')
             inputFile = bandSplit[0]
+            out_bands = '+' + bandSplit[1]
         else:
             inputFile = jobFile
+            out_bands = ''
 
         status = 'success'
         recipe_string = RQ_recipe.RecipeGet()
         no_extension_inputfile = os.path.join(work_dir, os.path.splitext(os.path.basename(jobFile))[0])
-        processes = generate_processes(jobFile, recipe_string, logger, no_extension_inputfile=no_extension_inputfile)
+        processes = generate_processes(jobFile, recipe_string, logger, no_extension_inputfile=no_extension_inputfile, out_bands=out_bands)
         failing_command = process(processes, work_dir, logger)
 
         if failing_command:

--- a/recipe/new/mo_themis_ir_edr.json
+++ b/recipe/new/mo_themis_ir_edr.json
@@ -45,7 +45,7 @@
                 "cksmithed": "yes"
             },
             "isis.cam2map": {
-                "from": "{{no_extension_inputfile}}.cub",
+                "from": "{{no_extension_inputfile}}.cub{{out_bands}}",
                 "to": "{{no_extension_inputfile}}.proj.cub",
                 "map": "value",
                 "matchmap": "no",


### PR DESCRIPTION
Define a new jinja token called `{{out_bands}}` to hold a list of 1 or 3 band numbers to be passed as part of an ISIS command downstream of `spiceinit` in recipes for multiband datasets. If a user does not specifically request a band or 3 bands as part of the job, `out_bands` will equal an empty string.
Commit includes a working example of `{{out_bands}}` in use in the THEMIS IR POW recipe.

Fixes #479