### PR TITLE
Support multiband input to derived_process

### DIFF
--- a/pds_pipelines/config.py
+++ b/pds_pipelines/config.py
@@ -28,6 +28,7 @@ pow_map2_base = '/pds_san/PDS_Services/'
 web_base = 'https://pdsimage.wr.usgs.gov/Missions/'
 archive_base = '/pds_san/PDS_Archive/'
 derived_base = '/pds_san/PDS_Derived/UPC/images/'
+derived_url = 'https://upcimages.wr.usgs.gov/'
 link_dest = '/pds_san/PDS_Archive_Links/'
 
 # Recipe base path

--- a/recipe/new/mo_themis_ir_edr.json
+++ b/recipe/new/mo_themis_ir_edr.json
@@ -56,44 +56,35 @@
     },
     "reduced": {
         "recipe": {
-            "thm2isis": {
-                "from_": "value",
-                "to": "value"
+            "isis.thm2isis": {
+                "from_": "{{inputfile}}",
+                "to": "{{no_extension_inputfile}}.cub"
             },
-            "cubeatt": {
-                "from_": "value",
-                "to": "value"
+            "get_single_band_cube": {
+                "cube": "{{no_extension_inputfile}}.cub",
+                "out_cube": "{{no_extension_inputfile}}.singleband.cub",
+	    	"band_list" : [9,8,7,6,5,4,3,2,1],
+	    	"keyname" : "FilterNumber"
             },
-            "reduce": {
-                "from_": "value",
-                "to": "value",
-                "algorithm": "average",
-                "mode": "scale",
-                "sscale": "value",
-                "lscale": "value",
-                "validper": "1",
-                "vper_replace": "nearest"
-            },
-            "isis2std": {
-                "from_": "value",
-                "to": "value",
-                "format": "jpeg",
-                "quality": "60",
-                "stretch": "linear"
+            "gdal_translate": {
+	    	"outputType": "Byte",
+	    	"format" : "JPEG",
+	    	"scaleParams": [[]],
+	    	"width" : "50",
+	    	"height" : "0",
+	    	"src" : "{{no_extension_inputfile}}.singleband.cub",
+	    	"dest": "{{derived_product}}.thumbnail.jpg"
+      	    },
+            "gdal_translate": {
+                "outputType": "Byte",
+                "format" : "JPEG",
+                "scaleParams": [[]],
+                "width" : "200",
+                "height" : "0",
+                "src" : "{{no_extension_inputfile}}.singleband.cub",
+                "dest": "{{derived_product}}.browse.jpg"
             }
-        },
-	"browse": {
-	    "minlines": "200",
-	    "minsamples": "200",
-	    "maxlines": "900",
-	    "maxsamples": "900"
-	},
-	"thumbnail": {
-	    "minlines": "50",
-	    "minsamples": "50",
-	    "maxlines": "300",
-	    "maxsamples": "300"
-	}
+        }
     },
     "projected": {
         "recipe": {


### PR DESCRIPTION
Added a convenience function to `available_modules.py` called `get_single_band_cube()` that essentially replicates the old logic for identifying a band to use for browse/thumbnail images. This is important for multispectral datasets such as THEMIS IR where certain bands are more likely to yield more aesthetically-pleasing thumbnails than others, but not all bands are present in every image and there is no way to know which bands are present without inspecting the label of the ISIS cube after running (in this case) `thm2isis`. The old browse/thumbnail process scripts had to run to `PDSinfo.json` to retrieve the name of the keyword that stored the filter numbers in the product label, as well as retrieve the prioritized list of band numbers to use for browse/thumbnails. This PR leaves `PDSinfo.json` untouched but adds both this keyword name and list of band numbers to the derived recipe in `mo_themis_ir_edr.json`. This approach can be applied to other multiband datasets in the future, such as THEMIS VIS, MARCI and the WACs from various other missions.

Also added the default value of `derived_url` to `config.py`

Fixes #478