### PR TITLE
Loggy Fix

### DIFF
--- a/pds_pipelines/pow_process.py
+++ b/pds_pipelines/pow_process.py
@@ -15,7 +15,7 @@ from pds_pipelines.redis_lock import RedisLock
 from pds_pipelines.redis_hash import RedisHash
 from pds_pipelines.pds_logging import Loggy
 from pds_pipelines.pds_process_logging import SubLoggy
-from pds_pipelines.utils import generate_processes, process
+from pds_pipelines.utils import generate_processes, process, generate_log_json
 
 
 def parse_args():
@@ -85,7 +85,8 @@ def main(user_args):
         recipe_string = RQ_recipe.RecipeGet()
         no_extension_inputfile = os.path.join(work_dir, os.path.splitext(os.path.basename(jobFile))[0])
         processes = generate_processes(jobFile, recipe_string, logger, no_extension_inputfile=no_extension_inputfile)
-        failing_command = process(processes, work_dir, logger)
+        failing_command, error = process(processes, work_dir, logger)
+        process_log = generate_log_json(processes, basename, failing_command, error)
 
         if failing_command:
             status = 'error'
@@ -109,12 +110,9 @@ def main(user_args):
 
         elif status == 'error':
             RHash.Status('ERROR')
-            if os.path.isfile(infile):
-                #os.remove(infile)
-                pass
 
         try:
-            RQ_loggy.QueueAdd(loggyOBJ.Loggy2json())
+            RQ_loggy.QueueAdd(process_log)
             RQ_work.QueueRemove(jobFile)
             logger.info('JSON Added to Loggy Queue')
         except:

--- a/pds_pipelines/service_final.py
+++ b/pds_pipelines/service_final.py
@@ -15,7 +15,7 @@ from collections import OrderedDict
 from pds_pipelines.redis_queue import RedisQueue
 from pds_pipelines.redis_hash import RedisHash
 from pds_pipelines.pds_db_query import PDS_DBquery
-from pds_pipelines.config import pds_log, pow_map2_base, scratch
+from pds_pipelines.config import pds_log, pow_map2_base, workarea, default_namespace
 from pysis import ISIS_VERSION as isis_version
 
 
@@ -55,6 +55,10 @@ def parse_args():
 def main(user_args):
     key = user_args.key
     namespace = user_args.namespace
+
+    if namespace is None:
+        namespace = default_namespace
+
     log_level = user_args.log_level
 
 #***************** Setup Logging **************
@@ -113,8 +117,8 @@ def main(user_args):
             logger.error('Adding Error XML to JOBS DB: Error')
         print(errorxml)
 
-    Fdir = pow_map2_base + infoHash.Service() + '/' + key
-    Wpath = scratch + key
+    Fdir = os.path.join(pow_map2_base, infoHash.Service(), key)
+    Wpath = os.path.join(workarea, key)
 
     # Make final directory
     if not os.path.exists(Fdir):
@@ -168,9 +172,9 @@ def main(user_args):
                     if k == 'status':
                         logOBJ.write(
                             "               STATUS:     " + val + "\n")
-                    elif k == 'command':
+                    elif k == 'parameters':
                         logOBJ.write(
-                            "               COMMAND:    " + val + "\n")
+                            "               PARAMETERS: " + val + "\n")
                     elif k == 'helplink':
                         logOBJ.write(
                             "               HELP LINK:  " + val + "\n\n")
@@ -182,7 +186,7 @@ def main(user_args):
     logOBJ.close()
 
 #******** Block for to copy and zip files to final directory ******
-    Zfile = Wpath + '/' + key + '.zip'
+    Zfile = os.path.join(Wpath, key + '.zip')
     logger.info('Making Zip File %s', Zfile)
 
 # log file stuff
@@ -194,8 +198,8 @@ def main(user_args):
         (stdout, stderr) = process.communicate()
 #        zOBJ.write(outputLOG, arcname=Lfile)
         logger.info('Log file %s Added to Zip File: Success', Lfile)
-        logger.info('zip stdout: ' + stdout)
-        logger.info('zip stderr: ' + stderr)
+        logger.info('zip stdout: ' + stdout.decode('utf-8'))
+        logger.info('zip stderr: ' + stderr.decode('utf-8'))
     except:
         logger.error('Log File %s NOT Added to Zip File', Lfile)
 
@@ -216,8 +220,8 @@ def main(user_args):
         (stdout, stderr) = process.communicate()
 
         logger.info('Map file %s added to zip file: Success', map_file)
-        logger.info('zip stdout: ' + stdout)
-        logger.info('zip stderr: ' + stderr)
+        logger.info('zip stdout: ' + stdout.decode('utf-8'))
+        logger.info('zip stderr: ' + stderr.decode('utf-8'))
     except:
         logger.error('Map File %s NOT added to Zip File', map_file)
 

--- a/pds_pipelines/tests/test_upc.py
+++ b/pds_pipelines/tests/test_upc.py
@@ -27,7 +27,7 @@ pysis.isis.getkey = getkey
 
 # Stub in the getsn function for testing
 def spiceinit(from_):
-    raise ProcessError(1, ['spiceinit'], '', '')
+    raise ProcessError(1, ['spiceinit'], b'Could not spiceinit', b'Could not spiceinit')
 pysis.isis.spiceinit = spiceinit
 
 import pds_pipelines
@@ -325,13 +325,15 @@ def test_process_isis():
 
     processes = {'isis.getsn': {'from_': '/Path/to/some/cube.cub'}}
 
-    failing_command = process(processes, '/', logger)
+    failing_command, error = process(processes, '/', logger)
     assert failing_command == ''
+    assert error == ''
 
 def test_bad_process_isis():
     logger = logging.getLogger('UPC_Process')
 
     processes = {'isis.spiceinit': {'from_': '/Path/to/some/cube.cub'}}
 
-    failing_command = process(processes, '/', logger)
+    failing_command, error = process(processes, '/', logger)
     assert failing_command == 'spiceinit'
+    assert error != ''

--- a/pds_pipelines/upc_process.py
+++ b/pds_pipelines/upc_process.py
@@ -491,7 +491,7 @@ def main(user_args):
                                        no_extension_inputfile=no_extension_inputfile,
                                        cam_info_file=cam_info_file,
                                        footprint_file=footprint_file)
-        failing_command, error = process(processes, workarea, logger)
+        failing_command, _ = process(processes, workarea, logger)
 
         pds_label = pvl.load(inputfile)
 

--- a/pds_pipelines/upc_process.py
+++ b/pds_pipelines/upc_process.py
@@ -491,7 +491,7 @@ def main(user_args):
                                        no_extension_inputfile=no_extension_inputfile,
                                        cam_info_file=cam_info_file,
                                        footprint_file=footprint_file)
-        failing_command = process(processes, workarea, logger)
+        failing_command, error = process(processes, workarea, logger)
 
         pds_label = pvl.load(inputfile)
 

--- a/pds_pipelines/utils.py
+++ b/pds_pipelines/utils.py
@@ -49,6 +49,7 @@ def generate_processes(inputfile, recipe_string, logger, **kwargs):
 def process(processes, workarea_pwd, logger):
     # iterate through functions from the processes dictionary
     failing_command = ''
+    error = ''
     for process, keywargs in processes.items():
         try:
             module, command = process.split('.')
@@ -70,9 +71,10 @@ def process(processes, workarea_pwd, logger):
             logger.debug("%s", e)
             logger.debug("%s", e.stderr)
             failing_command = command
+            error = e.stderr.decode('utf-8')
             break
 
-    return failing_command
+    return failing_command, error
 
 
 def get_isis_id(infile):
@@ -139,3 +141,28 @@ def add_process_db(session, fid, outvalue):
         return 'SUCCESS'
     except:
         return 'ERROR'
+
+def generate_log_json(processes, basename, failing_command = '', error = ''):
+    isis_help_link = 'https://isis.astrogeology.usgs.gov/Application/presentation/Tabbed/{0}/{0}.html'
+
+    log_json = {basename: {}}
+    for process in processes:
+        process_log = {}
+        process_log['status'] = 'SUCCESS'
+        process_log['parameters'] = str(processes[process])
+        process = process.split('.')[-1]
+        
+        if process in dir(isis):
+            process_log['helplink'] = isis_help_link.format(process)
+
+        if process == 'gdal_translate':
+            process_log['helplink'] = f'www.gdal.org/{process}.html'
+
+        if process == failing_command:
+            process_log['status'] = 'ERROR'
+            process_log['error'] = error
+            log_json[basename][process] = process_log
+            break
+        else:
+            log_json[basename][process] = process_log
+    return json.dumps(log_json)

--- a/pds_pipelines/utils.py
+++ b/pds_pipelines/utils.py
@@ -4,6 +4,7 @@ import json
 import pds_pipelines
 import datetime
 import pytz
+import pds_pipelines
 from pds_pipelines.available_modules import *
 from pds_pipelines.models import pds_models
 from pysis.exceptions import ProcessError
@@ -155,7 +156,7 @@ def generate_log_json(processes, basename, failing_command = '', error = ''):
         if process in dir(isis):
             process_log['helplink'] = isis_help_link.format(process)
 
-        if process == 'gdal_translate':
+        if process in dir(pds_pipelines.available_modules):
             process_log['helplink'] = f'www.gdal.org/{process}.html'
 
         if process == failing_command:


### PR DESCRIPTION
Fixes #477 where the logging broke after PR #473 

A quick overview is that the processes are collected into dictionary detailing every successfully run command in the pipeline, along with a help link for each command. This fix also populates the loggy queue appropriately when a POW or MAP2 job finishes.

See issue #477 for more details on the bug.