### PR TITLE
Correctly handle summing mode >1 in CTX POW jobs

### DIFF
--- a/pds_pipelines/service_job_manager.py
+++ b/pds_pipelines/service_job_manager.py
@@ -628,6 +628,8 @@ def generate_pow_recipe(xmlOBJ, pds_label, MAPfile):
         spatial_summing = pds_label.get('SAMPLING_FACTOR')
         if spatial_summing != 1:
             recipeOBJ.pop('isis.ctxevenodd')
+        else:
+            recipeOBJ.pop('cube_rename')
 
     if 'isis.mocevenodd' in recipe_processes:
         cross_track_summing = pds_label.get('CROSSTRACK_SUMMING')

--- a/recipe/new/mro_ctx.json
+++ b/recipe/new/mro_ctx.json
@@ -59,6 +59,10 @@
                 "from_": "{{no_extension_inputfile}}.cal.cub",
                 "to": "{{no_extension_inputfile}}.cal.eo.cub"
             },
+            "cube_rename": {
+                "src": "{{no_extension_inputfile}}.cal.cub",
+                "dest": "{{no_extension_inputfile}}.cal.eo.cub"
+            },
             "isis.cam2map": {
                 "from": "{{no_extension_inputfile}}.cal.eo.cub",
                 "to": "{{no_extension_inputfile}}.proj.cub",


### PR DESCRIPTION
Added optional call to `cube_rename()` in mro_ctx POW recipe to ensure `cam2map` gets input named in a way that it's expecting even if `ctxevenodd` is skipped. Added corresponding mutual exclusion logic in `service_job_manager.py` to either skip `ctxevenodd` or `cube_rename` as appropriate, depending on the summing mode of the input image.

resolves #465 