### PR TITLE
make_map.py: Change how PVL of map templates is encoded

### DIFF
--- a/pds_pipelines/make_map.py
+++ b/pds_pipelines/make_map.py
@@ -157,7 +157,7 @@ class MakeMap(object):
         """
         self.mapDICT['End_Group'] = 'Mapping'
 
-        mappvl = pvl.dumps(self.mapDICT)
+        mappvl = pvl.dumps(self.mapDICT, encoder=pvl.encoder.ISISEncoder())
         self.mappvl = mappvl
 
         return mappvl
@@ -179,7 +179,4 @@ class MakeMap(object):
         filename
         """
         self.mapDICT['End_Group'] = 'Mapping'
-        tempPVL = pvl.dumps(self.mapDICT)
-
-        with open(filename, 'wb') as f:
-            f.write(tempPVL.encode())
+        pvl.dump(self.mapDICT, filename, encoder=pvl.encoder.ISISEncoder())


### PR DESCRIPTION
Specifically invoke the ISIS encoder to ensure that keywords in the map template are camel case instead of all caps.
Tested on POW job [c961f25e1e943432809457db16ad9e95](https://astrocloud.wr.usgs.gov/index.php?view=viewjob&key=c961f25e1e943432809457db16ad9e95) and verified that both the resulting map template and final projected GeoTIFF are correct.

Fixes #502 