### PR TITLE
Switch link_artifacts.py to get paths from PDSinfo.json, plus miscellaneous small bugfixes

### DIFF
--- a/pds_pipelines/di_process.py
+++ b/pds_pipelines/di_process.py
@@ -69,7 +69,7 @@ def main(user_args):
             Qelement = session.query(Files).filter(
                 Files.filename == inputfile).one()
         except Exception as e:
-            logger.warn('Filename query failed for inputfile %s: %s', inputfile, str(e))
+            logger.warning('Filename query failed for inputfile %s: %s', inputfile, str(e))
             continue
 
         archive_path = PDSinfoDICT[archive]['path']
@@ -84,7 +84,7 @@ def main(user_args):
 
             Qelement.di_pass = checksum == Qelement.checksum
             if !Qelement.di_pass:
-                logger.warn('File %s checksum %s does not match the database entry checksum %s', 
+                logger.warning('File %s checksum %s does not match the database entry checksum %s', 
                             cpfile, checksum, Qelement.checksum)
 
             Qelement.di_date = datetime.datetime.now(
@@ -97,13 +97,13 @@ def main(user_args):
                 index = 0
         else:
             RQ_error.QueueAdd(f'Unable to locate or access {inputfile} during DI processing')
-            logger.warn('File %s Not Found', cpfile)
+            logger.warning('File %s Not Found', cpfile)
     try:
         session.commit()
         logger.info("End Commit DI process to Database: Success")
         index = 1
     except Exception as e:
-        logger.warn("Unable to commit changes to database\n\n%s", e)
+        logger.warning("Unable to commit changes to database\n\n%s", e)
         session.rollback()
 
     # Close connection to database

--- a/pds_pipelines/di_queueing.py
+++ b/pds_pipelines/di_queueing.py
@@ -107,7 +107,7 @@ def main(user_args):
             RQ.QueueAdd((element.filename, archive))
             addcount = addcount + 1
         except:
-            logger.warn('File %s Not Added to DI_ReadyQueue',
+            logger.warning('File %s Not Added to DI_ReadyQueue',
                          element.filename)
 
     logger.info('Files Added to Queue %s', addcount)

--- a/pds_pipelines/hpc_job.py
+++ b/pds_pipelines/hpc_job.py
@@ -161,8 +161,6 @@ class HPCjob(object):
             if self.memory:
                 f.write("\n" + self.memory)
 
-            f.write("\n#SBATCH --spread-job")
-
             if self.module:
                 f.write("\n\n" + self.module)
                 f.write("\necho `printenv PATH`")

--- a/pds_pipelines/ingest_process.py
+++ b/pds_pipelines/ingest_process.py
@@ -73,7 +73,7 @@ def main(user_args):
 
         if not os.path.isfile(inputfile):
             RQ_error.QueueAdd(f'Unable to locate or access {inputfile} during ingest processing')
-            logger.warn("%s is not a file\n", inputfile)
+            logger.warning("%s is not a file\n", inputfile)
             continue
 
         RQ_work.QueueAdd(inputfile)
@@ -137,7 +137,7 @@ def main(user_args):
 
         elif not runflag and not override:
             RQ_work.QueueRemove(inputfile)
-            logger.warn("Not running ingest: file %s already present"
+            logger.warning("Not running ingest: file %s already present"
                         " in database and no override flag supplied", inputfile)
 
         if index >= 250:
@@ -147,7 +147,7 @@ def main(user_args):
                 index = 1
             except Exception as e:
                 session.rollback()
-                logger.warn("Unable to commit to database: %s", str(e))
+                logger.warning("Unable to commit to database: %s", str(e))
     else:
         logger.info("No Files Found in Ingest Queue")
         try:

--- a/pds_pipelines/ingest_queueing.py
+++ b/pds_pipelines/ingest_queueing.py
@@ -88,7 +88,7 @@ def main(user_args):
                     if ingest:
                         RQ_ingest.QueueAdd((fname, archive))
                 except Exception as e:
-                    logger.warn('File %s NOT added to Ingest Queue: %s', fname, str(e))
+                    logger.warning('File %s NOT added to Ingest Queue: %s', fname, str(e))
             else:
                 continue
 

--- a/pds_pipelines/link_artifacts.py
+++ b/pds_pipelines/link_artifacts.py
@@ -5,14 +5,14 @@ import pvl
 import json
 import logging
 import argparse
-from pds_pipelines.config import recipe_base, link_dest
+from pds_pipelines.config import pds_info, link_dest
 from pds_pipelines.redis_queue import RedisQueue
 from ast import literal_eval
 from pds_pipelines.config import pds_log
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="DI Process")
+    parser = argparse.ArgumentParser(description="Create symbolic links named like PDS DATA_SET_ID for a given item in the Redis queue named LinkQueue. Symlinks are created in location defined by link_dest in PDS-Pipelines config.py.")
 
     parser.add_argument('--log', '-l', dest="log_level",
                         choices=['DEBUG', 'INFO',
@@ -44,14 +44,12 @@ def main(user_args):
         inputfile = item[0]
         archive = item[1]
 
-        json_file_path = recipe_base + archive + '.json'
+        PDSinfoDICT = json.load(open(pds_info, 'r'))
         try:
-            with open(json_file_path, 'r') as f:
-                json_dict = json.load(f)
-        except ValueError as e:
-            logging.warn(e)
+            link_src_path = PDSinfoDICT[archive]['path'][:-1]
+        except ValueError:
+            logger.warning(e)
             continue
-        link_src_path = json_dict['src']
 
         voldesc = load_pvl(inputfile)
         dataset_id = voldesc['VOLUME']['DATA_SET_ID']

--- a/pds_pipelines/pow_process.py
+++ b/pds_pipelines/pow_process.py
@@ -99,7 +99,8 @@ def main(user_args):
             if final_process == 'gdal_translate':
                 finalfile = args['dest']
             else:
-                finalfile = args['to']
+                finalfile_split = args['to'].split('+')
+                finalfile = finalfile_split[0]
 
             if RHash.getStatus() != 'ERROR':
                 RHash.Status('SUCCESS')

--- a/pds_pipelines/service_job_manager.py
+++ b/pds_pipelines/service_job_manager.py
@@ -926,7 +926,7 @@ def main(user_args):
             RQ_file.QueueAdd(Input_file)
             logger.info('File %s Added to Redis Queue', Input_file)
         except Exception as e:
-            logger.warn('File %s NOT Added to Redis Queue', Input_file)
+            logger.warning('File %s NOT Added to Redis Queue', Input_file)
             print('Redis Queue Error', e)
     RedisH.FileCount(RQ_file.QueueSize())
     logger.info('Count of Files Queue: %s', str(RQ_file.QueueSize()))
@@ -1073,7 +1073,7 @@ def main(user_args):
         RQ_recipe.QueueAdd(json.dumps(recipeOBJ))
         logger.info('Recipe Added to Redis')
     except Exception as e:
-        logger.warn('Recipe NOT Added to Redis: %s', recipeOBJ)
+        logger.warning('Recipe NOT Added to Redis: %s', recipeOBJ)
 
     # HPC job stuff
     logger.info('HPC Cluster job Submission Starting')


### PR DESCRIPTION
Changed `link_artifacts.py` to read path to archive from `PDSinfo.json` instead of individual recipe files (Fixes #505), plus updated description in argparse help (Fixes #506).

pow_process.py now correctly splits filenames on '+' character in cases when output format is an ISIS cube and there are other attributes specified, such as a simple stretch or a change in bit type (Fixes #504).

Replaced instances of `.warn()` with `.warning()` throughout code (Fixes #495). Removed `--spread-job` SBATCH parameter from `hpc_job.py` so HPC jobs will no longer use it (Fixes #507).