### PR TITLE
Update appropriate queues/hashes with error messages

### DIFF
--- a/pds_pipelines/map_process.py
+++ b/pds_pipelines/map_process.py
@@ -128,7 +128,7 @@ def main(user_args):
                     finalfile_aux = os.path.join(work_dir, RHash.getMAPname() + '.' + fileext + '.aux.xml')
                     shutil.move(last_output_aux, finalfile_aux)
                     final_file_list.append(finalfile_aux)
-                                    
+
             shutil.move(last_output, finalfile)
             final_file_list.append(finalfile)
 
@@ -151,8 +151,12 @@ def main(user_args):
                 logger.error(f'JSON NOT Added to Loggy Queue with error: {e}')
 
             RQ_work.QueueRemove(jobFile)
+
         elif status == 'error':
             RHash.Status('ERROR')
+            error_string = f'Error Executing {failing_command}' \
+                           f'Standard Error: {error}'
+            RHerror.addError(basename, error_string)
             if os.path.isfile(infile):
                 os.remove(infile)
 

--- a/pds_pipelines/pow_process.py
+++ b/pds_pipelines/pow_process.py
@@ -127,7 +127,7 @@ def main(user_args):
 
         elif status == 'error':
             RHash.Status('ERROR')
-            logger.error(f'Process {k} :: Error')
+            logger.error(f'Process {failing_command} :: Error')
             logger.error(error)
             error_string = f'Error Executing {failing_command}' \
                            f'Standard Error: {error}'

--- a/pds_pipelines/pow_process.py
+++ b/pds_pipelines/pow_process.py
@@ -107,7 +107,7 @@ def main(user_args):
 
             # Add finalfile to a list (it may be the only item if there are no ancillary files)
             final_file_list = [finalfile]
-            
+
             # Possible ancillary files
             finalfile_aux = finalfile + '.aux.xml'
             finalfile_msk = finalfile + '.msk'
@@ -127,6 +127,12 @@ def main(user_args):
 
         elif status == 'error':
             RHash.Status('ERROR')
+            logger.error(f'Process {k} :: Error')
+            logger.error(error)
+            error_string = f'Error Executing {failing_command}' \
+                           f'Standard Error: {error}'
+            RHerror.addError(basename, error_string)
+            RQ_error.QueueAdd(f'Process {failing_command} failed for {jobFile}')
 
         try:
             RQ_loggy.QueueAdd(process_log)


### PR DESCRIPTION
Adds back in error queueing that was removed in a refactor some time ago. This means that errors should appropriately be queued for the associated map2/pow jobs if/when they error.

Closes #513