### PR TITLE
Allow users to import the library with no active DB connection

### DIFF
--- a/pds_pipelines/db.py
+++ b/pds_pipelines/db.py
@@ -32,6 +32,12 @@ def db_connect(cred):
                                                                     c[cred]['db']))
     except KeyError:
         print("Credentials not found for {}".format(cred))
+
+    try:
+        engine.connect()
+    except sqlalchemy.exc.OperationalError:
+        print(f"WARNING:  Unable to create a database connection for credential specification '{cred}'")
+        return None, None
     metadata = MetaData(bind=engine)
     session_maker = sessionmaker(bind=engine)
     return session_maker, engine


### PR DESCRIPTION
returns none/none (sessionmaker / engine) if the the engine does not yield a valid connection.

I'm now able to use:
import pds_pipelines
from pds_pipelines import *
from pds_pipelines.models import upc_models
from pds_pipelines.models import pds_models

Closes #386 