### PR TITLE
Fid Removal

### DIFF
--- a/pds_pipelines/derived_process.py
+++ b/pds_pipelines/derived_process.py
@@ -13,7 +13,7 @@ from pds_pipelines.redis_lock import RedisLock
 from pds_pipelines.db import db_connect
 from pds_pipelines.models.upc_models import DataFiles, SearchTerms, JsonKeywords
 from pds_pipelines.config import pds_log, pds_info, workarea, pds_db, upc_db, lock_obj, upc_error_queue, recipe_base, archive_base, derived_base, derived_url, web_base
-from pds_pipelines.utils import generate_processes, process, parse_pairs, add_process_db
+from pds_pipelines.utils import generate_processes, process, parse_pairs
 
 def makedir(inputfile):
     temppath = os.path.dirname(inputfile)
@@ -70,8 +70,7 @@ def main():
         item = literal_eval(RQ_derived.QueueGet())
 
         inputfile = item[0]
-        fid = item[1]
-        archive = item[2]
+        archive = item[1]
         if os.path.isfile(inputfile):
             recipe_file = recipe_base + "/" + archive + '.json'
             with open(recipe_file) as fp:
@@ -99,7 +98,6 @@ def main():
                 upc_session.close()
                 #os.remove(infile)
                 logger.info(f'Derived Process Success: %s', inputfile)
-                add_process_db(pds_session_maker, fid, 't')
             else:
                 logger.error('Error: %s', failing_command)
 

--- a/pds_pipelines/utils.py
+++ b/pds_pipelines/utils.py
@@ -69,8 +69,8 @@ def process(processes, workarea_pwd, logger):
                 func(**keywargs)
 
         except ProcessError as e:
-            logger.info("%s", e)
-            logger.info("%s", e.stderr)
+            logger.debug("%s", e)
+            logger.debug("%s", e.stderr)
             failing_command = command
             error = e.stderr.decode('utf-8')
             break
@@ -78,7 +78,7 @@ def process(processes, workarea_pwd, logger):
         except RuntimeError as e:
             failing_command = command
             error = e
-            logger.info("%s", error)
+            logger.debug("%s", error)
 
     return failing_command, error
 

--- a/pds_pipelines/utils.py
+++ b/pds_pipelines/utils.py
@@ -69,11 +69,16 @@ def process(processes, workarea_pwd, logger):
                 func(**keywargs)
 
         except ProcessError as e:
-            logger.debug("%s", e)
-            logger.debug("%s", e.stderr)
+            logger.info("%s", e)
+            logger.info("%s", e.stderr)
             failing_command = command
             error = e.stderr.decode('utf-8')
             break
+
+        except RuntimeError as e:
+            failing_command = command
+            error = e
+            logger.info("%s", error)
 
     return failing_command, error
 


### PR DESCRIPTION
This removes the fid from being pushed to the derived ready queue. Following this, the process is no longer being added to the process run table in the di database.

Closes #457 