### PR TITLE
Refactored upc_process and upc_queueing for threadsafe updates

### DIFF
--- a/pds_pipelines/upc_process.py
+++ b/pds_pipelines/upc_process.py
@@ -100,7 +100,6 @@ def main(user_args):
                                            cam_info_file=cam_info_file,
                                            footprint_file=footprint_file)
             failing_command, _ = process(processes, workarea, logger)
-            RQ_update.QueueAdd((inputfile, archive, failing_command, 'upc'))
 
         if derived:
             if os.path.isfile(inputfile):
@@ -122,10 +121,13 @@ def main(user_args):
                                                derived_product=derived_product)
                 failing_command, _ = process(processes, workarea, logger)
 
-                if not failing_command:
-                    RQ_update.QueueAdd((inputfile, archive, failing_command, 'derived'))
-                else:
-                    logger.error('Error: %s', failing_command)
+        if failing_command:
+            logger.warn(logger.error('%s Processing Error: %s', inputfile, failing_command))
+
+        if proc:
+            RQ_update.QueueAdd((inputfile, archive, failing_command, 'upc'))
+        elif derived:
+            RQ_update.QueueAdd((inputfile, archive, failing_command, 'derived'))
 
         RQ_work.QueueRemove(item)
     logger.info("UPC processing exited")

--- a/pds_pipelines/upc_update.py
+++ b/pds_pipelines/upc_update.py
@@ -520,7 +520,8 @@ def main(user_args):
                 with session_scope(upc_session_maker) as session:
                     JsonKeywords.create(session, **json_keywords_attributes)
 
-            # Always attempt derived processing
+            # Derived Processing:
+
             # If we don't have a upcid, get the matching ID from the database
             if not 'upc_id' in locals():
                 with session_scope(upc_session_maker) as session:

--- a/pds_pipelines/upc_update.py
+++ b/pds_pipelines/upc_update.py
@@ -430,6 +430,7 @@ def main(user_args):
         archive = item_list[1]
         failing_command = item_list[2]
         update_type = item_list[3]
+        upc_id = None
 
         if not os.path.isfile(inputfile):
             RQ_error.QueueAdd(f'Unable to locate or access {inputfile} during UPC update')
@@ -441,7 +442,6 @@ def main(user_args):
 
         # Update the logger context to include inputfile
         context['inputfile'] = inputfile
-
 
         try:
             session = upc_session_maker()
@@ -523,7 +523,7 @@ def main(user_args):
             # Derived Processing:
 
             # If we don't have a upcid, get the matching ID from the database
-            if not 'upc_id' in locals():
+            if not upc_id:
                 with session_scope(upc_session_maker) as session:
                     src = inputfile.replace(workarea, web_base)
                     datafile = session.query(DataFiles).filter(or_(DataFiles.source == src,

--- a/pds_pipelines/upc_update.py
+++ b/pds_pipelines/upc_update.py
@@ -527,6 +527,11 @@ def main(user_args):
                     src = inputfile.replace(workarea, web_base)
                     datafile = session.query(DataFiles).filter(or_(DataFiles.source == src,
                                                                    DataFiles.detached_label == src)).first()
+                    if not datafile:
+                        RQ_error.QueueAdd(f'No matching upcid was found for {inputfile}, '
+                                          'derived product paths could not be added')
+                        logger.warning(f'No matching upcid was found for %s, '
+                                       'derived product paths could not be added', inputfile)
                     upc_id = datafile.upcid
 
             final_path = makedir(inputfile)


### PR DESCRIPTION
Refactored upc_process and upc_queueing for threadsafe updating.

Previously, upc_process produced and enqueued two update jobs, one for the upc update and one for derived products.  This was problematic because the derived product update depended on a upcid being in the database.

This commit refactors upc_process so that it only produces and enqueues a single job.  If the job is of type 'upc,' then upc_update will add the upc information and attempt to input derived information.  If no derived products are found, then it skips that portion.  If the job is of type 'derived,' then upc_update will search for a matching upcid and update the record with the derived information.